### PR TITLE
Fix leading zeros on chapter, verse, and navbar

### DIFF
--- a/ScriptureRenderingPipeline/Helpers/MarkdigExtensions/RCLinkRenderer.cs
+++ b/ScriptureRenderingPipeline/Helpers/MarkdigExtensions/RCLinkRenderer.cs
@@ -28,6 +28,13 @@ namespace ScriptureRenderingPipeline.Helpers.MarkdigExtensions
         public string GenerateLink(RCLink input)
         {
             var rawLink = input.Link.ToString();
+            
+            // HACK: If the link doesn't contain slashes, for now ignore it.
+            if (!rawLink.Contains("/"))
+            {
+                return rawLink;
+            }
+
             var splitLink = rawLink.Split("/");
             var language = splitLink[2];
             var resource = splitLink[3];

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -78,7 +78,7 @@ namespace ScriptureRenderingPipeline.Renderers
                 foreach(var chapter in book.Chapters)
                 {
                     // Remove leading zeros from chapter
-                    string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                    string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
                     navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString,book.BookId,chapter.ChapterNumber), title = printableChapterNumber });
                 }
                 output.Add(navBook);

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -77,7 +77,9 @@ namespace ScriptureRenderingPipeline.Renderers
                 var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
                 foreach(var chapter in book.Chapters)
                 {
-                    navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString,book.BookId,chapter.ChapterNumber), title = chapter.ChapterNumber });
+                    // Remove leading zeros from chapter
+                    string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                    navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString,book.BookId,chapter.ChapterNumber), title = printableChapterNumber });
                 }
                 output.Add(navBook);
             }

--- a/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
@@ -35,7 +35,9 @@ namespace ScriptureRenderingPipeline.Renderers
         {
             if (chapter.ChapterNumber != "front")
             {
-                builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {chapter.ChapterNumber}</h2>");
+                // Remove leading zeros from chapter
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });              
+                builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {printableChapterNumber}</h2>");
             }
             else
             {

--- a/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
@@ -24,8 +24,8 @@ namespace ScriptureRenderingPipeline.Renderers
             if (!(chapter.ChapterNumber == "front" || verse.VerseNumber == "intro"))
             {
                 // Remove leading zeros from chapter and verse
-                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
-                string printableVerseNumber = verse.VerseNumber.TrimStart(new char[] { '0' });
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
+                string printableVerseNumber = verse.VerseNumber.TrimStart('0');
                 builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {printableChapterNumber}:{printableVerseNumber}</h2>");
             }
             else
@@ -39,7 +39,7 @@ namespace ScriptureRenderingPipeline.Renderers
             if (chapter.ChapterNumber != "front")
             {
                 // Remove leading zeros from chapter
-                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });              
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');              
                 builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {printableChapterNumber}</h2>");
             }
             else

--- a/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationNotesRenderer.cs
@@ -23,7 +23,10 @@ namespace ScriptureRenderingPipeline.Renderers
         {
             if (!(chapter.ChapterNumber == "front" || verse.VerseNumber == "intro"))
             {
-                builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {chapter.ChapterNumber}:{verse.VerseNumber}</h2>");
+                // Remove leading zeros from chapter and verse
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                string printableVerseNumber = verse.VerseNumber.TrimStart(new char[] { '0' });
+                builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {printableChapterNumber}:{printableVerseNumber}</h2>");
             }
             else
             {

--- a/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
@@ -17,8 +17,8 @@ namespace ScriptureRenderingPipeline.Renderers
             if (!(chapter.ChapterNumber == "front" || verse.VerseNumber == "intro"))
             {
                 // Remove leading zeros from chapter and verse
-                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
-                string printableVerseNumber = verse.VerseNumber.TrimStart(new char[] { '0' });
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
+                string printableVerseNumber = verse.VerseNumber.TrimStart('0');
                 builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {printableChapterNumber}:{printableVerseNumber}</h2>");
             }
             else
@@ -32,7 +32,7 @@ namespace ScriptureRenderingPipeline.Renderers
             if (chapter.ChapterNumber != "front")
             {
                 // Remove leading zeros from chapter
-                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
                 builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {printableChapterNumber}</h2>");
             }
             else

--- a/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
@@ -16,7 +16,10 @@ namespace ScriptureRenderingPipeline.Renderers
         {
             if (!(chapter.ChapterNumber == "front" || verse.VerseNumber == "intro"))
             {
-                builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {chapter.ChapterNumber}:{verse.VerseNumber}</h2>");
+                // Remove leading zeros from chapter and verse
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                string printableVerseNumber = verse.VerseNumber.TrimStart(new char[] { '0' });
+                builder.AppendLine($"<h1 id=\"{string.Format(VerseFormatString, book.BookId, chapter.ChapterNumber, verse.VerseNumber)}\">{book.BookName} {printableChapterNumber}:{printableVerseNumber}</h2>");
             }
             else
             {

--- a/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationQuestionsRenderer.cs
@@ -28,7 +28,9 @@ namespace ScriptureRenderingPipeline.Renderers
         {
             if (chapter.ChapterNumber != "front")
             {
-                builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {chapter.ChapterNumber}</h2>");
+                // Remove leading zeros from chapter
+                string printableChapterNumber = chapter.ChapterNumber.TrimStart(new char[] { '0' });
+                builder.AppendLine($"<h1 id=\"{string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber)}\">{book.BookName} {printableChapterNumber}</h2>");
             }
             else
             {


### PR DESCRIPTION
This comprises the following changes
- Remove leading zeros from chapter headings, e.g. "Genesis 09"
- Remove leading zeros from chapter/verse heading, e.g. "Genesis 09:02"
- Remove leading zeros from navbar buttons
- Temporary fix to prevent crashing on rc links that don't contain slashes, like in jer/49/12.md: "[[:en:ta:vol2:translate:figs_doublenegatives]]"