### PR TITLE
added json files to support easier downloading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			// Use IntelliSense to find out which attributes exist for C# debugging
+			// Use hover for the description of the existing attributes
+			// For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+			"name": ".NET Core Launch (console)",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			// If you have changed target frameworks, make sure to update the program path.
+			"program": "${workspaceFolder}/SRPTests/bin/Debug/net6.0/SRPTests.dll",
+			"args": [],
+			"cwd": "${workspaceFolder}/SRPTests",
+			// For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+			"console": "internalConsole",
+			"stopAtEntry": false
+		},
+		{
+			"name": ".NET Core Attach",
+			"type": "coreclr",
+			"request": "attach"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "build",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"build",
+				"${workspaceFolder}/SRPTests/SRPTests.csproj",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "publish",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"publish",
+				"${workspaceFolder}/SRPTests/SRPTests.csproj",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "watch",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"watch",
+				"run",
+				"--project",
+				"${workspaceFolder}/SRPTests/SRPTests.csproj"
+			],
+			"problemMatcher": "$msCompile"
+		}
+	]
+}

--- a/PipelineCommon/Helpers/Utils.cs
+++ b/PipelineCommon/Helpers/Utils.cs
@@ -12,352 +12,352 @@ using System.Threading.Tasks;
 
 namespace PipelineCommon.Helpers
 {
-    public static class Utils
-    {
-        public static void DownloadRepo(string url, string repoDir, ILogger log)
-        {
-            string repoZipFile = Path.Join(CreateTempFolder(), url.Substring(url.LastIndexOf("/")));
+	public static class Utils
+	{
+		public static void DownloadRepo(string url, string repoDir, ILogger log)
+		{
+			string repoZipFile = Path.Join(CreateTempFolder(), url.Substring(url.LastIndexOf("/")));
 
-            if (File.Exists(repoZipFile))
-            {
-                File.Delete(repoZipFile);
-            }
+			if (File.Exists(repoZipFile))
+			{
+				File.Delete(repoZipFile);
+			}
 
-            using (WebClient client = new WebClient())
-            {
-                log.LogInformation($"Downloading {url} to {repoZipFile}");
-                client.DownloadFile(new Uri(url), repoZipFile);
-            }
+			using (WebClient client = new WebClient())
+			{
+				log.LogInformation($"Downloading {url} to {repoZipFile}");
+				client.DownloadFile(new Uri(url), repoZipFile);
+			}
 
-            log.LogInformation($"unzipping {repoZipFile} to {repoDir}");
-            ZipFile.ExtractToDirectory(repoZipFile, repoDir);
-        }
+			log.LogInformation($"unzipping {repoZipFile} to {repoDir}");
+			ZipFile.ExtractToDirectory(repoZipFile, repoDir);
+		}
 
-        public static string GetRepoFiles(string commitUrl, ILogger log)
-        {
-            string tempDir = CreateTempFolder();
-            DownloadRepo(commitUrl, tempDir, log);
-            string repoDir = Path.Join(tempDir, Guid.NewGuid().ToString());
-            if (!Directory.Exists(repoDir))
-            {
-                repoDir = tempDir;
-            }
-            // Need to grab the first dir out of the zip
-            return Directory.EnumerateDirectories(repoDir).First();
-        }
+		public static string GetRepoFiles(string commitUrl, ILogger log)
+		{
+			string tempDir = CreateTempFolder();
+			DownloadRepo(commitUrl, tempDir, log);
+			string repoDir = Path.Join(tempDir, Guid.NewGuid().ToString());
+			if (!Directory.Exists(repoDir))
+			{
+				repoDir = tempDir;
+			}
+			// Need to grab the first dir out of the zip
+			return Directory.EnumerateDirectories(repoDir).First();
+		}
 
-        /// <summary>
-        /// Create a temporary folder that has a unique name
-        /// </summary>
-        /// <returns>A unique folder under the temporary directory</returns>
-        public static string CreateTempFolder()
-        {
-            string path = Path.Join(Path.GetTempPath() ,Guid.NewGuid().ToString());
-            Directory.CreateDirectory(path);
-            return path;
-        }
+		/// <summary>
+		/// Create a temporary folder that has a unique name
+		/// </summary>
+		/// <returns>A unique folder under the temporary directory</returns>
+		public static string CreateTempFolder()
+		{
+			string path = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString());
+			Directory.CreateDirectory(path);
+			return path;
+		}
 
-        /// <summary>
-        /// A list of bible books in order
-        /// </summary>
-        public static List<string> BibleBookOrder = new List<string>() {
-            "GEN",
-            "EXO",
-            "LEV",
-            "NUM",
-            "DEU",
-            "JOS",
-            "JDG",
-            "RUT",
-            "1SA",
-            "2SA",
-            "1KI",
-            "2KI",
-            "1CH",
-            "2CH",
-            "EZR",
-            "NEH",
-            "EST",
-            "JOB",
-            "PSA",
-            "PRO",
-            "ECC",
-            "SNG",
-            "ISA",
-            "JER",
-            "LAM",
-            "EZK",
-            "DAN",
-            "HOS",
-            "JOL",
-            "AMO",
-            "OBA",
-            "JON",
-            "MIC",
-            "NAM",
-            "HAB",
-            "ZEP",
-            "HAG",
-            "ZEC",
-            "MAL",
-            "MAT",
-            "MRK",
-            "LUK",
-            "JHN",
-            "ACT",
-            "ROM",
-            "1CO",
-            "2CO",
-            "GAL",
-            "EPH",
-            "PHP",
-            "COL",
-            "1TH",
-            "2TH",
-            "1TI",
-            "2TI",
-            "TIT",
-            "PHM",
-            "HEB",
-            "JAS",
-            "1PE",
-            "2PE",
-            "1JN",
-            "2JN",
-            "3JN",
-            "JUD",
-            "REV"
-        };
-        /// <summary>
-        /// A mapping between bible book abbreviations and their English names. Note that this shouldn't exist and only does because
-        /// of lack of localization for translationNotes and translationQuestions
-        /// </summary>
-        public static Dictionary<string, string> bookAbbrivationMappingToEnglish = new Dictionary<string, string>()
-        {
-            ["GEN"] = "Genesis",
-            ["EXO"] = "Exodus",
-            ["LEV"] = "Leviticus",
-            ["NUM"] = "Numbers",
-            ["DEU"] = "Deuteronomy",
-            ["JOS"] = "Joshua",
-            ["JDG"] = "Judges",
-            ["RUT"] = "Ruth",
-            ["1SA"] = "1 Samuel",
-            ["2SA"] = "2 Samuel",
-            ["1KI"] = "1 Kings",
-            ["2KI"] = "2 Kings",
-            ["1CH"] = "1 Chronicles",
-            ["2CH"] = "2 Chronicles",
-            ["EZR"] = "Ezra",
-            ["NEH"] = "Nehemiah",
-            ["EST"] = "Esther",
-            ["JOB"] = "Job",
-            ["PSA"] = "Psalms",
-            ["PRO"] = "Proverbs",
-            ["ECC"] = "Ecclesiastes",
-            ["SNG"] = "Song of Songs",
-            ["ISA"] = "Isaiah",
-            ["JER"] = "Jeremiah",
-            ["LAM"] = "Lamentations",
-            ["EZK"] = "Ezekiel",
-            ["DAN"] = "Daniel",
-            ["HOS"] = "Hosea",
-            ["JOL"] = "Joel",
-            ["AMO"] = "Amos",
-            ["OBA"] = "Obadiah",
-            ["JON"] = "Jonah",
-            ["MIC"] = "Micah",
-            ["NAM"] = "Nahum",
-            ["HAB"] = "Habakkuk",
-            ["ZEP"] = "Zephaniah",
-            ["HAG"] = "Haggai",
-            ["ZEC"] = "Zechariah",
-            ["MAL"] = "Malachi",
-            ["MAT"] = "Matthew",
-            ["MRK"] = "Mark",
-            ["LUK"] = "Luke",
-            ["JHN"] = "John",
-            ["ACT"] = "Acts",
-            ["ROM"] = "Romans",
-            ["1CO"] = "1 Corinthians",
-            ["2CO"] = "2 Corinthians",
-            ["GAL"] = "Galatians",
-            ["EPH"] = "Ephesians",
-            ["PHP"] = "Philippians",
-            ["COL"] = "Colossians",
-            ["1TH"] = "1 Thessalonians",
-            ["2TH"] = "2 Thessalonians",
-            ["1TI"] = "1 Timothy",
-            ["2TI"] = "2 Timothy",
-            ["TIT"] = "Titus",
-            ["PHM"] = "Philemon",
-            ["HEB"] = "Hebrews",
-            ["JAS"] = "James",
-            ["1PE"] = "1 Peter",
-            ["2PE"] = "2 Peter",
-            ["1JN"] = "1 John",
-            ["2JN"] = "2 John",
-            ["3JN"] = "3 John",
-            ["JUD"] = "Jude",
-            ["REV"] = "Revelation",
-        };
+		/// <summary>
+		/// A list of bible books in order
+		/// </summary>
+		public static List<string> BibleBookOrder = new List<string>() {
+						"GEN",
+						"EXO",
+						"LEV",
+						"NUM",
+						"DEU",
+						"JOS",
+						"JDG",
+						"RUT",
+						"1SA",
+						"2SA",
+						"1KI",
+						"2KI",
+						"1CH",
+						"2CH",
+						"EZR",
+						"NEH",
+						"EST",
+						"JOB",
+						"PSA",
+						"PRO",
+						"ECC",
+						"SNG",
+						"ISA",
+						"JER",
+						"LAM",
+						"EZK",
+						"DAN",
+						"HOS",
+						"JOL",
+						"AMO",
+						"OBA",
+						"JON",
+						"MIC",
+						"NAM",
+						"HAB",
+						"ZEP",
+						"HAG",
+						"ZEC",
+						"MAL",
+						"MAT",
+						"MRK",
+						"LUK",
+						"JHN",
+						"ACT",
+						"ROM",
+						"1CO",
+						"2CO",
+						"GAL",
+						"EPH",
+						"PHP",
+						"COL",
+						"1TH",
+						"2TH",
+						"1TI",
+						"2TI",
+						"TIT",
+						"PHM",
+						"HEB",
+						"JAS",
+						"1PE",
+						"2PE",
+						"1JN",
+						"2JN",
+						"3JN",
+						"JUD",
+						"REV"
+				};
+		/// <summary>
+		/// A mapping between bible book abbreviations and their English names. Note that this shouldn't exist and only does because
+		/// of lack of localization for translationNotes and translationQuestions
+		/// </summary>
+		public static Dictionary<string, string> bookAbbreviationMappingToEnglish = new Dictionary<string, string>()
+		{
+			["GEN"] = "Genesis",
+			["EXO"] = "Exodus",
+			["LEV"] = "Leviticus",
+			["NUM"] = "Numbers",
+			["DEU"] = "Deuteronomy",
+			["JOS"] = "Joshua",
+			["JDG"] = "Judges",
+			["RUT"] = "Ruth",
+			["1SA"] = "1 Samuel",
+			["2SA"] = "2 Samuel",
+			["1KI"] = "1 Kings",
+			["2KI"] = "2 Kings",
+			["1CH"] = "1 Chronicles",
+			["2CH"] = "2 Chronicles",
+			["EZR"] = "Ezra",
+			["NEH"] = "Nehemiah",
+			["EST"] = "Esther",
+			["JOB"] = "Job",
+			["PSA"] = "Psalms",
+			["PRO"] = "Proverbs",
+			["ECC"] = "Ecclesiastes",
+			["SNG"] = "Song of Songs",
+			["ISA"] = "Isaiah",
+			["JER"] = "Jeremiah",
+			["LAM"] = "Lamentations",
+			["EZK"] = "Ezekiel",
+			["DAN"] = "Daniel",
+			["HOS"] = "Hosea",
+			["JOL"] = "Joel",
+			["AMO"] = "Amos",
+			["OBA"] = "Obadiah",
+			["JON"] = "Jonah",
+			["MIC"] = "Micah",
+			["NAM"] = "Nahum",
+			["HAB"] = "Habakkuk",
+			["ZEP"] = "Zephaniah",
+			["HAG"] = "Haggai",
+			["ZEC"] = "Zechariah",
+			["MAL"] = "Malachi",
+			["MAT"] = "Matthew",
+			["MRK"] = "Mark",
+			["LUK"] = "Luke",
+			["JHN"] = "John",
+			["ACT"] = "Acts",
+			["ROM"] = "Romans",
+			["1CO"] = "1 Corinthians",
+			["2CO"] = "2 Corinthians",
+			["GAL"] = "Galatians",
+			["EPH"] = "Ephesians",
+			["PHP"] = "Philippians",
+			["COL"] = "Colossians",
+			["1TH"] = "1 Thessalonians",
+			["2TH"] = "2 Thessalonians",
+			["1TI"] = "1 Timothy",
+			["2TI"] = "2 Timothy",
+			["TIT"] = "Titus",
+			["PHM"] = "Philemon",
+			["HEB"] = "Hebrews",
+			["JAS"] = "James",
+			["1PE"] = "1 Peter",
+			["2PE"] = "2 Peter",
+			["1JN"] = "1 John",
+			["2JN"] = "2 John",
+			["3JN"] = "3 John",
+			["JUD"] = "Jude",
+			["REV"] = "Revelation",
+		};
 
-        /// <summary>
-        /// Get the book number for a specific abbreviation
-        /// </summary>
-        /// <param name="bookAbbreviation">The abbreviation to look up</param>
-        /// <returns>The book number or 0 if it isn't a valid book</returns>
-        /// <remarks>Book number 40 is the apocrypha and is unused so that is why Matthew is 41</remarks>
-        public static int GetBookNumber(string bookAbbreviation)
-        {
-            bookAbbreviation = bookAbbreviation.ToUpper();
-            if (!BibleBookOrder.Contains(bookAbbreviation))
-            {
-                return 0;
-            }
-            var index = BibleBookOrder.IndexOf(bookAbbreviation) + 1;
-            if (index >= 40)
-            {
-                index++;
-            }
-            return index;
-        }
+		/// <summary>
+		/// Get the book number for a specific abbreviation
+		/// </summary>
+		/// <param name="bookAbbreviation">The abbreviation to look up</param>
+		/// <returns>The book number or 0 if it isn't a valid book</returns>
+		/// <remarks>Book number 40 is the apocrypha and is unused so that is why Matthew is 41</remarks>
+		public static int GetBookNumber(string bookAbbreviation)
+		{
+			bookAbbreviation = bookAbbreviation.ToUpper();
+			if (!BibleBookOrder.Contains(bookAbbreviation))
+			{
+				return 0;
+			}
+			var index = BibleBookOrder.IndexOf(bookAbbreviation) + 1;
+			if (index >= 40)
+			{
+				index++;
+			}
+			return index;
+		}
 
-        /// <summary>
-        /// A list of identifiers for bible books
-        /// </summary>
-        public static readonly List<string> BibleIdentifiers = new List<string>()
-        {
-            "ulb",
-            "reg",
-            "udb",
-            "cuv",
-            "uhb",
-            "ugnt",
-            "blv",
-            "f10",
-            "nav",
-            "ayt",
-            "rlv",
-            "ust",
-        };
+		/// <summary>
+		/// A list of identifiers for bible books
+		/// </summary>
+		public static readonly List<string> BibleIdentifiers = new List<string>()
+				{
+						"ulb",
+						"reg",
+						"udb",
+						"cuv",
+						"uhb",
+						"ugnt",
+						"blv",
+						"f10",
+						"nav",
+						"ayt",
+						"rlv",
+						"ust",
+				};
 
-        public static Dictionary<string, RepoType> RepoTypeMapping = new Dictionary<string, RepoType>()
-        {
-            ["tn"] = RepoType.translationNotes,
-            ["tw"] = RepoType.translationWords,
-            ["tq"] = RepoType.translationQuestions,
-            ["ta"] = RepoType.translationAcademy,
-            ["tm"] = RepoType.translationAcademy,
-            ["obs"] = RepoType.OpenBibleStories,
-            ["bc"] = RepoType.BibleCommentary,
-        };
+		public static Dictionary<string, RepoType> RepoTypeMapping = new Dictionary<string, RepoType>()
+		{
+			["tn"] = RepoType.translationNotes,
+			["tw"] = RepoType.translationWords,
+			["tq"] = RepoType.translationQuestions,
+			["ta"] = RepoType.translationAcademy,
+			["tm"] = RepoType.translationAcademy,
+			["obs"] = RepoType.OpenBibleStories,
+			["bc"] = RepoType.BibleCommentary,
+		};
 
-        /// <summary>
-        /// Figures out what type a resource is based on it's identifier
-        /// </summary>
-        /// <param name="resourceIdentifier">The identifer to look up</param>
-        /// <returns>The resource type</returns>
-        public static RepoType GetRepoType(string resourceIdentifier)
-        {
-            var bibleIdentifiersFropmEnvironment = Environment.GetEnvironmentVariable("BibleIdentifiers");
-            if (bibleIdentifiersFropmEnvironment != null)
-            {
-                if(bibleIdentifiersFropmEnvironment.Split(",").Select(i => i.Trim()).Any(i => i == resourceIdentifier))
-                {
-                    return RepoType.Bible;
-                }
-            }
-            if (BibleIdentifiers.Contains(resourceIdentifier))
-            {
-                return RepoType.Bible;
-            }
+		/// <summary>
+		/// Figures out what type a resource is based on it's identifier
+		/// </summary>
+		/// <param name="resourceIdentifier">The identifer to look up</param>
+		/// <returns>The resource type</returns>
+		public static RepoType GetRepoType(string resourceIdentifier)
+		{
+			var bibleIdentifiersFropmEnvironment = Environment.GetEnvironmentVariable("BibleIdentifiers");
+			if (bibleIdentifiersFropmEnvironment != null)
+			{
+				if (bibleIdentifiersFropmEnvironment.Split(",").Select(i => i.Trim()).Any(i => i == resourceIdentifier))
+				{
+					return RepoType.Bible;
+				}
+			}
+			if (BibleIdentifiers.Contains(resourceIdentifier))
+			{
+				return RepoType.Bible;
+			}
 
-            if (RepoTypeMapping.ContainsKey(resourceIdentifier))
-            {
-                return RepoTypeMapping[resourceIdentifier];
-            }
-            return RepoType.Unknown;
-        }
-        /// <summary>
-        /// Upload files to Azure storage
-        /// </summary>
-        /// <param name="log"></param>
-        /// <param name="connectionString"></param>
-        /// <param name="outputContainer"></param>
-        /// <param name="sourceDir"></param>
-        /// <param name="basePath"></param>
-        /// <returns></returns>
-        public static async Task UploadToStorage(ILogger log, string connectionString, string outputContainer, string sourceDir, string basePath)
-        {
-            var extentionToMimeTypeMatching = new Dictionary<string, string>()
-            {
-                [".html"] = "text/html",
-                [".json"] = "application/json",
-            };
-            BlobContainerClient outputClient = new BlobContainerClient(connectionString, outputContainer);
-            outputClient.CreateIfNotExists();
-            List<Task> uploadTasks = new List<Task>();
-            foreach(var file in Directory.GetFiles(sourceDir, "*.*", SearchOption.AllDirectories))
-            {
-                var relativePath = Path.GetRelativePath(sourceDir, file);
-                var extension = Path.GetExtension(relativePath);
-                log.LogDebug($"Uploading {relativePath}");
-                var tmp = outputClient.GetBlobClient(Path.Join(basePath,relativePath ).Replace("\\","/"));
-                tmp.DeleteIfExists();
-                string contentType = extentionToMimeTypeMatching.ContainsKey(extension) ? extentionToMimeTypeMatching[extension] : "application/octet-stream";
-                uploadTasks.Add(tmp.UploadAsync(file, new BlobUploadOptions() { HttpHeaders = new BlobHttpHeaders() { ContentType = contentType } }));
-            };
-            await Task.WhenAll(uploadTasks);
-        }
+			if (RepoTypeMapping.ContainsKey(resourceIdentifier))
+			{
+				return RepoTypeMapping[resourceIdentifier];
+			}
+			return RepoType.Unknown;
+		}
+		/// <summary>
+		/// Upload files to Azure storage
+		/// </summary>
+		/// <param name="log"></param>
+		/// <param name="connectionString"></param>
+		/// <param name="outputContainer"></param>
+		/// <param name="sourceDir"></param>
+		/// <param name="basePath"></param>
+		/// <returns></returns>
+		public static async Task UploadToStorage(ILogger log, string connectionString, string outputContainer, string sourceDir, string basePath)
+		{
+			var extentionToMimeTypeMatching = new Dictionary<string, string>()
+			{
+				[".html"] = "text/html",
+				[".json"] = "application/json",
+			};
+			BlobContainerClient outputClient = new BlobContainerClient(connectionString, outputContainer);
+			outputClient.CreateIfNotExists();
+			List<Task> uploadTasks = new List<Task>();
+			foreach (var file in Directory.GetFiles(sourceDir, "*.*", SearchOption.AllDirectories))
+			{
+				var relativePath = Path.GetRelativePath(sourceDir, file);
+				var extension = Path.GetExtension(relativePath);
+				log.LogDebug($"Uploading {relativePath}");
+				var tmp = outputClient.GetBlobClient(Path.Join(basePath, relativePath).Replace("\\", "/"));
+				tmp.DeleteIfExists();
+				string contentType = extentionToMimeTypeMatching.ContainsKey(extension) ? extentionToMimeTypeMatching[extension] : "application/octet-stream";
+				uploadTasks.Add(tmp.UploadAsync(file, new BlobUploadOptions() { HttpHeaders = new BlobHttpHeaders() { ContentType = contentType } }));
+			};
+			await Task.WhenAll(uploadTasks);
+		}
 
-        // TODO: Pull out into it's own utils
-        public static async Task<List<string>> ListAllFilesUnderPath(BlobContainerClient outputClient, string prefix)
-        {
-            var output = new List<string>();
-            var stack = new Stack<string>(new List<string>() { prefix});
-            while(stack.Count > 0)
-            {
-                var directory = stack.Pop();
-                await foreach (var file in outputClient.GetBlobsByHierarchyAsync(prefix: directory, delimiter: "/"))
-                {
-                    if (file.IsBlob)
-                    {
-                        output.Add(file.Blob.Name);
-                        continue;
-                    }
-                    // otherwise this is folder
-                    stack.Push(file.Prefix);
+		// TODO: Pull out into it's own utils
+		public static async Task<List<string>> ListAllFilesUnderPath(BlobContainerClient outputClient, string prefix)
+		{
+			var output = new List<string>();
+			var stack = new Stack<string>(new List<string>() { prefix });
+			while (stack.Count > 0)
+			{
+				var directory = stack.Pop();
+				await foreach (var file in outputClient.GetBlobsByHierarchyAsync(prefix: directory, delimiter: "/"))
+				{
+					if (file.IsBlob)
+					{
+						output.Add(file.Blob.Name);
+						continue;
+					}
+					// otherwise this is folder
+					stack.Push(file.Prefix);
 
-                }
-            }
-            return output;
-        }
+				}
+			}
+			return output;
+		}
 
-        public static List<string> TranslationWordsValidSections = new List<string>()
-        {
-            "kt",
-            "names",
-            "other"
-        };
+		public static List<string> TranslationWordsValidSections = new List<string>()
+				{
+						"kt",
+						"names",
+						"other"
+				};
 
-        public static Dictionary<string, string> TranslationWordsTitleMapping = new Dictionary<string, string>()
-        {
-            ["kt"] = "Key Terms",
-            ["names"] = "Names",
-            ["other"] = "Other",
-        };
-    }
-    public enum RepoType
-    {
-        Unknown,
-        Bible,
-        bttWriterProject,
-        translationWords,
-        translationAcademy,
-        translationQuestions,
-        translationNotes,
-        OpenBibleStories,
-        BibleCommentary,
-    }
+		public static Dictionary<string, string> TranslationWordsTitleMapping = new Dictionary<string, string>()
+		{
+			["kt"] = "Key Terms",
+			["names"] = "Names",
+			["other"] = "Other",
+		};
+	}
+	public enum RepoType
+	{
+		Unknown,
+		Bible,
+		bttWriterProject,
+		translationWords,
+		translationAcademy,
+		translationQuestions,
+		translationNotes,
+		OpenBibleStories,
+		BibleCommentary,
+	}
 }

--- a/ScriptureRenderingPipeline/Models/OutputChapters.cs
+++ b/ScriptureRenderingPipeline/Models/OutputChapters.cs
@@ -4,8 +4,10 @@ namespace ScriptureRenderingPipeline.Models;
 
 public class OutputChapters
 {
-    [JsonPropertyName("number")]
-    public string Number { get; set; }
-    [JsonPropertyName("label")]
-    public string Label { get; set; }
+	[JsonPropertyName("number")]
+	public string Number { get; set; }
+	[JsonPropertyName("label")]
+	public string Label { get; set; }
+	[JsonPropertyName("value")]
+	public string Value { get; set; }
 }

--- a/ScriptureRenderingPipeline/Models/OutputChapters.cs
+++ b/ScriptureRenderingPipeline/Models/OutputChapters.cs
@@ -8,6 +8,9 @@ public class OutputChapters
 	public string Number { get; set; }
 	[JsonPropertyName("label")]
 	public string Label { get; set; }
-	[JsonPropertyName("value")]
-	public string Value { get; set; }
+	[JsonPropertyName("content")]
+	public string Content { get; set; }
+
+	[JsonPropertyName("byteCount")]
+	public int ByteCount { get; set; }
 }

--- a/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
+++ b/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ScriptureRenderingPipeline.Models;
+
+public class DownloadIndex
+{
+	[JsonPropertyName("data")]
+	public List<OutputBook> Data { get; set; }
+}

--- a/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
+++ b/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
@@ -5,6 +5,13 @@ namespace ScriptureRenderingPipeline.Models;
 
 public class DownloadIndex
 {
-	[JsonPropertyName("data")]
-	public List<OutputBook> Data { get; set; }
+	[JsonPropertyName("content")]
+	public List<OutputBook> Content { get; set; }
+
+	public long ByteCount { get; set; }
+
+	public DownloadIndex()
+	{
+		Content = new List<OutputBook>();
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
@@ -16,183 +16,152 @@ using USFMToolsSharp.Renderers.USFM;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-	public static class BibleRenderer
-	{
-		private static readonly string ChapterFormatString = "ch-{0}";
+  public static class BibleRenderer
+  {
+    private static readonly string ChapterFormatString = "ch-{0}";
 
-		/// <summary>
-		/// Build scripture HTML files
-		/// </summary>
-		/// <param name="source">A ZipFileSystem to load the </param>
-		/// <param name="basePath">The base path inside of the zip file to pull data from</param>
-		/// <param name="destinationDir">Where to put the resulting HTML files</param>
-		/// <param name="printTemplate">The template to apply to the printable page</param>
-		/// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
-		/// <param name="heading">The heading for the template</param>
-		/// <param name="languageName">The language name of the project</param>
-		/// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
-		/// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
-		/// <param name="languageCode">The language code for the project</param>
-		public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
-		{
-			List<USFMDocument> documents;
-			var downloadLinks = new List<DownloadLink>();
-			if (isBTTWriterProject)
-			{
-				documents = new List<USFMDocument>() {
-										BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true))
-										};
-				USFMRenderer renderer = new USFMRenderer();
-				await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
-				downloadLinks.Add(new DownloadLink() { Link = "source.usfm", Title = "USFM" });
-			}
-			else
-			{
-				documents = await LoadDirectoryAsync(source);
-			}
+    /// <summary>
+    /// Build scripture HTML files
+    /// </summary>
+    /// <param name="source">A ZipFileSystem to load the </param>
+    /// <param name="basePath">The base path inside of the zip file to pull data from</param>
+    /// <param name="destinationDir">Where to put the resulting HTML files</param>
+    /// <param name="printTemplate">The template to apply to the printable page</param>
+    /// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
+    /// <param name="heading">The heading for the template</param>
+    /// <param name="languageName">The language name of the project</param>
+    /// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
+    /// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
+    /// <param name="languageCode">The language code for the project</param>
+    public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
+    {
+      List<USFMDocument> documents;
+      var downloadLinks = new List<DownloadLink>();
+      if (isBTTWriterProject)
+      {
+        documents = new List<USFMDocument>() {
+                              BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true))
+                              };
+        USFMRenderer renderer = new USFMRenderer();
+        await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
+        downloadLinks.Add(new DownloadLink() { Link = "source.usfm", Title = "USFM" });
+      }
+      else
+      {
+        documents = await LoadDirectoryAsync(source);
+      }
 
-			// Order by abbreviation
-			documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
-					?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
-					: 99).ToList();
+      // Order by abbreviation
+      documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
+            ?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
+            : 99).ToList();
 
-			var printBuilder = new StringBuilder();
-			var outputTasks = new List<Task>();
-			var index = new OutputIndex()
-			{
-				TextDirection = textDirection,
-				RepoUrl = repoUrl,
-				LanguageCode = languageCode,
-				LanguageName = languageName,
-				ResourceType = "bible",
-				Bible = new List<OutputBook>(),
-				DownloadLinks = downloadLinks
-			};
-			var downloadIndex = new DownloadIndex()
-			{
-				Data = new List<OutputBook>()
-			};
-			// var downloadIndex =
+      var printBuilder = new StringBuilder();
+      var outputTasks = new List<Task>();
+      var index = new OutputIndex()
+      {
+        TextDirection = textDirection,
+        RepoUrl = repoUrl,
+        LanguageCode = languageCode,
+        LanguageName = languageName,
+        ResourceType = "bible",
+        Bible = new List<OutputBook>(),
+        DownloadLinks = downloadLinks
+      };
+      foreach (var document in documents)
+      {
+        var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
+        var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
+        var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
+        var content = renderer.Render(document);
+        var chapters = document.GetChildMarkers<CMarker>();
+        Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
+        var outputBook = new OutputBook()
+        {
+          Slug = abbreviation,
+          Label = title
+        };
+        foreach (var chapter in chapters)
+        {
+          var tmp = new USFMDocument();
+          tmp.Insert(chapter);
+          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), renderer.Render(tmp)));
+          outputBook.Chapters.Add(new OutputChapters()
+          {
+            Number = chapter.Number.ToString(),
+            Label = chapter.PublishedChapterMarker
+          });
+        }
+        index.Bible.Add(outputBook);
 
-			foreach (var document in documents)
-			{
-				var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
-				var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
-				var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
-				var content = renderer.Render(document);
-				var chapters = document.GetChildMarkers<CMarker>();
-				Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
-				var outputBook = new OutputBook()
-				{
-					Slug = abbreviation,
-					Label = title
-				};
-				var outPutBookDataInclude = new OutputBook()
-				{
-					Slug = abbreviation,
-					Label = title
-				};
-				// var download
-				foreach (var chapter in chapters)
-				{
-					var tmp = new USFMDocument();
-					tmp.Insert(chapter);
-					var chapterContent = renderer.Render(tmp);
-					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), chapterContent));
-					outputBook.Chapters.Add(new OutputChapters()
-					{
-						Number = chapter.Number.ToString(),
-						Label = chapter.PublishedChapterMarker
-					});
-					var outputChapterWithHtml = new OutputChapters()
-					{
-						Number = chapter.Number.ToString(),
-						Label = chapter.PublishedChapterMarker,
-						Value = chapterContent
-					};
-					outPutBookDataInclude.Chapters.Add(new OutputChapters()
-					{
-						Number = chapter.Number.ToString(),
-						Label = chapter.PublishedChapterMarker,
-						Value = chapterContent
-					});
-				}
-				index.Bible.Add(outputBook);
-				downloadIndex.Data.Add(outPutBookDataInclude);
+        // Since the print all page isn't going to broken up then just write stuff out here
+        printBuilder.AppendLine(content);
+      }
 
-				// Add whole.json for each chapter for book level fetching
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, "whole.json"), JsonSerializer.Serialize(outPutBookDataInclude)));
+      // If we have something then create the print_all.html page and the index.html page
+      if (documents.Count > 0)
+      {
+        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+      }
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
 
-				// Since the print all page isn't going to broken up then just write stuff out here
-				printBuilder.AppendLine(content);
-			}
+      await Task.WhenAll(outputTasks);
+    }
+    /// <summary>
+    /// Load all USFM files in a directory inside of the ZipFileSystem
+    /// </summary>
+    /// <param name="directory">A ZipFileSystem to load from</param>
+    /// <returns>A list of USFM files</returns>
+    static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
+    {
+      USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
+      var output = new List<USFMDocument>();
+      foreach (var f in directory.GetAllFiles(".usfm"))
+      {
+        var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
+        // If we don't have an abbreviation then try to figure it out from the file name
+        var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
+        if (tableOfContentsMarkers.Count == 0)
+        {
+          var bookAbbrivation = GetBookAbberviationFromFileName(f);
+          if (bookAbbrivation != null)
+          {
+            tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbrivation });
+          }
+        }
+        else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
+        {
+          var bookAbbrivation = GetBookAbberviationFromFileName(f);
+          if (bookAbbrivation != null)
+          {
+            tableOfContentsMarkers[0].BookAbbreviation = bookAbbrivation;
+          }
+        }
+        output.Add(tmp);
+      }
+      return output;
+    }
 
-			// If we have something then create the print_all.html page and the index.html page
-			if (documents.Count > 0)
-			{
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-			}
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+    private static string GetBookAbberviationFromFileName(string f)
+    {
+      string bookAbbriviation = null;
+      var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
+      if (fileNameSplit.Length == 2)
+      {
+        if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
+        {
+          bookAbbriviation = fileNameSplit[1].ToUpper();
+        }
+      }
+      else if (fileNameSplit.Length == 1)
+      {
+        if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
+        {
+          bookAbbriviation = fileNameSplit[0].ToUpper();
+        }
+      }
 
-
-			await Task.WhenAll(outputTasks);
-		}
-		/// <summary>
-		/// Load all USFM files in a directory inside of the ZipFileSystem
-		/// </summary>
-		/// <param name="directory">A ZipFileSystem to load from</param>
-		/// <returns>A list of USFM files</returns>
-		static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
-		{
-			USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
-			var output = new List<USFMDocument>();
-			foreach (var f in directory.GetAllFiles(".usfm"))
-			{
-				var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
-				// If we don't have an abbreviation then try to figure it out from the file name
-				var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
-				if (tableOfContentsMarkers.Count == 0)
-				{
-					var bookAbbrivation = GetBookAbberviationFromFileName(f);
-					if (bookAbbrivation != null)
-					{
-						tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbrivation });
-					}
-				}
-				else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
-				{
-					var bookAbbrivation = GetBookAbberviationFromFileName(f);
-					if (bookAbbrivation != null)
-					{
-						tableOfContentsMarkers[0].BookAbbreviation = bookAbbrivation;
-					}
-				}
-				output.Add(tmp);
-			}
-			return output;
-		}
-
-		private static string GetBookAbberviationFromFileName(string f)
-		{
-			string bookAbbriviation = null;
-			var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
-			if (fileNameSplit.Length == 2)
-			{
-				if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
-				{
-					bookAbbriviation = fileNameSplit[1].ToUpper();
-				}
-			}
-			else if (fileNameSplit.Length == 1)
-			{
-				if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
-				{
-					bookAbbriviation = fileNameSplit[0].ToUpper();
-				}
-			}
-
-			return bookAbbriviation;
-		}
-	}
+      return bookAbbriviation;
+    }
+  }
 }

--- a/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
@@ -16,152 +16,177 @@ using USFMToolsSharp.Renderers.USFM;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-  public static class BibleRenderer
-  {
-    private static readonly string ChapterFormatString = "ch-{0}";
+	public static class BibleRenderer
+	{
+		private static readonly string ChapterFormatString = "ch-{0}";
 
-    /// <summary>
-    /// Build scripture HTML files
-    /// </summary>
-    /// <param name="source">A ZipFileSystem to load the </param>
-    /// <param name="basePath">The base path inside of the zip file to pull data from</param>
-    /// <param name="destinationDir">Where to put the resulting HTML files</param>
-    /// <param name="printTemplate">The template to apply to the printable page</param>
-    /// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
-    /// <param name="heading">The heading for the template</param>
-    /// <param name="languageName">The language name of the project</param>
-    /// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
-    /// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
-    /// <param name="languageCode">The language code for the project</param>
-    public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
-    {
-      List<USFMDocument> documents;
-      var downloadLinks = new List<DownloadLink>();
-      if (isBTTWriterProject)
-      {
-        documents = new List<USFMDocument>() {
-                              BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true))
-                              };
-        USFMRenderer renderer = new USFMRenderer();
-        await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
-        downloadLinks.Add(new DownloadLink() { Link = "source.usfm", Title = "USFM" });
-      }
-      else
-      {
-        documents = await LoadDirectoryAsync(source);
-      }
+		/// <summary>
+		/// Build scripture HTML files
+		/// </summary>
+		/// <param name="source">A ZipFileSystem to load the </param>
+		/// <param name="basePath">The base path inside of the zip file to pull data from</param>
+		/// <param name="destinationDir">Where to put the resulting HTML files</param>
+		/// <param name="printTemplate">The template to apply to the printable page</param>
+		/// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
+		/// <param name="heading">The heading for the template</param>
+		/// <param name="languageName">The language name of the project</param>
+		/// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
+		/// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
+		/// <param name="languageCode">The language code for the project</param>
+		public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
+		{
+			List<USFMDocument> documents;
+			var downloadLinks = new List<DownloadLink>();
+			if (isBTTWriterProject)
+			{
+				documents = new List<USFMDocument>() {
+					BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true))
+					};
+				USFMRenderer renderer = new USFMRenderer();
+				await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
+				downloadLinks.Add(new DownloadLink() { Link = "source.usfm", Title = "USFM" });
+			}
+			else
+			{
+				documents = await LoadDirectoryAsync(source);
+			}
 
-      // Order by abbreviation
-      documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
-            ?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
-            : 99).ToList();
+			// Order by abbreviation
+			documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
+						?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
+						: 99).ToList();
 
-      var printBuilder = new StringBuilder();
-      var outputTasks = new List<Task>();
-      var index = new OutputIndex()
-      {
-        TextDirection = textDirection,
-        RepoUrl = repoUrl,
-        LanguageCode = languageCode,
-        LanguageName = languageName,
-        ResourceType = "bible",
-        Bible = new List<OutputBook>(),
-        DownloadLinks = downloadLinks
-      };
-      foreach (var document in documents)
-      {
-        var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
-        var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
-        var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
-        var content = renderer.Render(document);
-        var chapters = document.GetChildMarkers<CMarker>();
-        Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
-        var outputBook = new OutputBook()
-        {
-          Slug = abbreviation,
-          Label = title
-        };
-        foreach (var chapter in chapters)
-        {
-          var tmp = new USFMDocument();
-          tmp.Insert(chapter);
-          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), renderer.Render(tmp)));
-          outputBook.Chapters.Add(new OutputChapters()
-          {
-            Number = chapter.Number.ToString(),
-            Label = chapter.PublishedChapterMarker
-          });
-        }
-        index.Bible.Add(outputBook);
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var index = new OutputIndex()
+			{
+				TextDirection = textDirection,
+				RepoUrl = repoUrl,
+				LanguageCode = languageCode,
+				LanguageName = languageName,
+				ResourceType = "bible",
+				Bible = new List<OutputBook>(),
+				DownloadLinks = downloadLinks
+			};
+			var downloadIndex = new DownloadIndex();
 
-        // Since the print all page isn't going to broken up then just write stuff out here
-        printBuilder.AppendLine(content);
-      }
+			foreach (var document in documents)
+			{
+				var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
+				var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
+				var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
+				var content = renderer.Render(document);
+				var chapters = document.GetChildMarkers<CMarker>();
+				Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
+				var outputBook = new OutputBook()
+				{
+					Slug = abbreviation,
+					Label = title
+				};
+				var bookWithContent = new OutputBook()
+				{
+					Slug = abbreviation,
+					Label = title
+				};
+				foreach (var chapter in chapters)
+				{
+					var tmp = new USFMDocument();
+					tmp.Insert(chapter);
+					var renderedContent = renderer.Render(tmp);
+					var byteCount = System.Text.Encoding.UTF8.GetBytes(renderedContent).Length;
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), renderedContent));
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Number = chapter.Number.ToString(),
+						Label = chapter.PublishedChapterMarker
+					});
+					bookWithContent.Chapters.Add(new OutputChapters()
+					{
+						Number = chapter.Number.ToString(),
+						Label = chapter.PublishedChapterMarker,
+						Content = renderedContent,
+						ByteCount = byteCount
+					});
+				}
+				index.Bible.Add(outputBook);
+				downloadIndex.Content.Add(bookWithContent);
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, "whole.json"), JsonSerializer.Serialize(bookWithContent)));
 
-      // If we have something then create the print_all.html page and the index.html page
-      if (documents.Count > 0)
-      {
-        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-      }
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
 
-      await Task.WhenAll(outputTasks);
-    }
-    /// <summary>
-    /// Load all USFM files in a directory inside of the ZipFileSystem
-    /// </summary>
-    /// <param name="directory">A ZipFileSystem to load from</param>
-    /// <returns>A list of USFM files</returns>
-    static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
-    {
-      USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
-      var output = new List<USFMDocument>();
-      foreach (var f in directory.GetAllFiles(".usfm"))
-      {
-        var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
-        // If we don't have an abbreviation then try to figure it out from the file name
-        var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
-        if (tableOfContentsMarkers.Count == 0)
-        {
-          var bookAbbrivation = GetBookAbberviationFromFileName(f);
-          if (bookAbbrivation != null)
-          {
-            tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbrivation });
-          }
-        }
-        else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
-        {
-          var bookAbbrivation = GetBookAbberviationFromFileName(f);
-          if (bookAbbrivation != null)
-          {
-            tableOfContentsMarkers[0].BookAbbreviation = bookAbbrivation;
-          }
-        }
-        output.Add(tmp);
-      }
-      return output;
-    }
+				// Since the print all page isn't going to broken up then just write stuff out here
+				printBuilder.AppendLine(content);
+			}
+			long totalByteCount = downloadIndex.Content
+		.SelectMany(outputBook => outputBook.Chapters)
+		.Sum(chapter => chapter.ByteCount);
+			downloadIndex.ByteCount = totalByteCount;
 
-    private static string GetBookAbberviationFromFileName(string f)
-    {
-      string bookAbbriviation = null;
-      var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
-      if (fileNameSplit.Length == 2)
-      {
-        if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
-        {
-          bookAbbriviation = fileNameSplit[1].ToUpper();
-        }
-      }
-      else if (fileNameSplit.Length == 1)
-      {
-        if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
-        {
-          bookAbbriviation = fileNameSplit[0].ToUpper();
-        }
-      }
+			// If we have something then create the print_all.html page and the index.html page
+			if (documents.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
 
-      return bookAbbriviation;
-    }
-  }
+			await Task.WhenAll(outputTasks);
+		}
+		/// <summary>
+		/// Load all USFM files in a directory inside of the ZipFileSystem
+		/// </summary>
+		/// <param name="directory">A ZipFileSystem to load from</param>
+		/// <returns>A list of USFM files</returns>
+		static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
+		{
+			USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
+			var output = new List<USFMDocument>();
+			foreach (var f in directory.GetAllFiles(".usfm"))
+			{
+				var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
+				// If we don't have an abbreviation then try to figure it out from the file name
+				var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
+				if (tableOfContentsMarkers.Count == 0)
+				{
+					var bookAbbreviation = GetBookAbberviationFromFileName(f);
+					if (bookAbbreviation != null)
+					{
+						tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbreviation });
+					}
+				}
+				else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
+				{
+					var bookAbbreviation = GetBookAbberviationFromFileName(f);
+					if (bookAbbreviation != null)
+					{
+						tableOfContentsMarkers[0].BookAbbreviation = bookAbbreviation;
+					}
+				}
+				output.Add(tmp);
+			}
+			return output;
+		}
+
+		private static string GetBookAbberviationFromFileName(string f)
+		{
+			string bookAbbreviation = null;
+			var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
+			if (fileNameSplit.Length == 2)
+			{
+				if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
+				{
+					bookAbbreviation = fileNameSplit[1].ToUpper();
+				}
+			}
+			else if (fileNameSplit.Length == 1)
+			{
+				if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
+				{
+					bookAbbreviation = fileNameSplit[0].ToUpper();
+				}
+			}
+
+			return bookAbbreviation;
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
@@ -16,152 +16,183 @@ using USFMToolsSharp.Renderers.USFM;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-    public static class BibleRenderer
-    {
-        private static readonly string ChapterFormatString = "ch-{0}";
+	public static class BibleRenderer
+	{
+		private static readonly string ChapterFormatString = "ch-{0}";
 
-        /// <summary>
-        /// Build scripture HTML files
-        /// </summary>
-        /// <param name="source">A ZipFileSystem to load the </param>
-        /// <param name="basePath">The base path inside of the zip file to pull data from</param>
-        /// <param name="destinationDir">Where to put the resulting HTML files</param>
-        /// <param name="printTemplate">The template to apply to the printable page</param>
-        /// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
-        /// <param name="heading">The heading for the template</param>
-        /// <param name="languageName">The language name of the project</param>
-        /// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
-        /// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
-        /// <param name="languageCode">The language code for the project</param>
-        public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
-        {
-            List<USFMDocument> documents;
-            var downloadLinks = new List<DownloadLink>();
-            if (isBTTWriterProject)
-            {
-                documents = new List<USFMDocument>() { 
-                    BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true)) 
-                    };
-                USFMRenderer renderer = new USFMRenderer();
-                await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
-                downloadLinks.Add(new DownloadLink(){Link = "source.usfm", Title = "USFM"});
-            }
-            else
-            {
-                documents = await LoadDirectoryAsync(source);
-            }
+		/// <summary>
+		/// Build scripture HTML files
+		/// </summary>
+		/// <param name="source">A ZipFileSystem to load the </param>
+		/// <param name="basePath">The base path inside of the zip file to pull data from</param>
+		/// <param name="destinationDir">Where to put the resulting HTML files</param>
+		/// <param name="printTemplate">The template to apply to the printable page</param>
+		/// <param name="repoUrl">The URL to inject into the template for the "See in WACS" link</param>
+		/// <param name="heading">The heading for the template</param>
+		/// <param name="languageName">The language name of the project</param>
+		/// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
+		/// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
+		/// <param name="languageCode">The language code for the project</param>
+		public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
+		{
+			List<USFMDocument> documents;
+			var downloadLinks = new List<DownloadLink>();
+			if (isBTTWriterProject)
+			{
+				documents = new List<USFMDocument>() {
+										BTTWriterLoader.CreateUSFMDocumentFromContainer(new ZipFileSystemBTTWriterLoader(source, basePath),false, new USFMParser(ignoreUnknownMarkers: true))
+										};
+				USFMRenderer renderer = new USFMRenderer();
+				await File.WriteAllTextAsync(Path.Join(destinationDir, "source.usfm"), renderer.Render(documents[0]));
+				downloadLinks.Add(new DownloadLink() { Link = "source.usfm", Title = "USFM" });
+			}
+			else
+			{
+				documents = await LoadDirectoryAsync(source);
+			}
 
-            // Order by abbreviation
-            documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
-                ?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
-                : 99).ToList();
-            
-            var printBuilder = new StringBuilder();
-            var outputTasks = new List<Task>();
-            var index = new OutputIndex()
-            {
-                TextDirection = textDirection,
-                RepoUrl = repoUrl,
-                LanguageCode = languageCode,
-                LanguageName = languageName,
-                ResourceType = "bible",
-                Bible = new List<OutputBook>(),
-                DownloadLinks = downloadLinks
-            };
-            foreach(var document in documents)
-            {
-                var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
-                var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
-                var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
-                var content = renderer.Render(document);
-                var chapters = document.GetChildMarkers<CMarker>();
-                Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
-                var outputBook = new OutputBook()
-                {
-                    Slug = abbreviation,
-                    Label = title
-                };
-                foreach (var chapter in chapters)
-                {
-                    var tmp = new USFMDocument();
-                    tmp.Insert(chapter);
-                    outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), renderer.Render(tmp)));
-                    outputBook.Chapters.Add(new OutputChapters()
-                    {
-                        Number = chapter.Number.ToString(),
-                        Label = chapter.PublishedChapterMarker
-                    });
-                }
-                index.Bible.Add(outputBook);
+			// Order by abbreviation
+			documents = documents.OrderBy(d => Utils.BibleBookOrder.Contains(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()
+					?.BookAbbreviation.ToUpper()) ? Utils.BibleBookOrder.IndexOf(d.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation.ToUpper())
+					: 99).ToList();
 
-                // Since the print all page isn't going to broken up then just write stuff out here
-                printBuilder.AppendLine(content);
-            }
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var index = new OutputIndex()
+			{
+				TextDirection = textDirection,
+				RepoUrl = repoUrl,
+				LanguageCode = languageCode,
+				LanguageName = languageName,
+				ResourceType = "bible",
+				Bible = new List<OutputBook>(),
+				DownloadLinks = downloadLinks
+			};
+			var downloadIndex = new DownloadIndex()
+			{
+				Data = new List<OutputBook>()
+			};
+			// var downloadIndex =
 
-            // If we have something then create the print_all.html page and the index.html page
-            if (documents.Count > 0)
-            {
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-            }
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
+			foreach (var document in documents)
+			{
+				var renderer = new HtmlRenderer(new HTMLConfig() { partialHTML = true, ChapterIdPattern = ChapterFormatString });
+				var abbreviation = document.GetChildMarkers<TOC3Marker>().FirstOrDefault()?.BookAbbreviation;
+				var title = document.GetChildMarkers<TOC2Marker>().FirstOrDefault()?.ShortTableOfContentsText ?? abbreviation;
+				var content = renderer.Render(document);
+				var chapters = document.GetChildMarkers<CMarker>();
+				Directory.CreateDirectory(Path.Join(destinationDir, abbreviation));
+				var outputBook = new OutputBook()
+				{
+					Slug = abbreviation,
+					Label = title
+				};
+				var outPutBookDataInclude = new OutputBook()
+				{
+					Slug = abbreviation,
+					Label = title
+				};
+				// var download
+				foreach (var chapter in chapters)
+				{
+					var tmp = new USFMDocument();
+					tmp.Insert(chapter);
+					var chapterContent = renderer.Render(tmp);
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, $"{chapter.Number.ToString()}.html"), chapterContent));
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Number = chapter.Number.ToString(),
+						Label = chapter.PublishedChapterMarker
+					});
+					var outputChapterWithHtml = new OutputChapters()
+					{
+						Number = chapter.Number.ToString(),
+						Label = chapter.PublishedChapterMarker,
+						Value = chapterContent
+					};
+					outPutBookDataInclude.Chapters.Add(new OutputChapters()
+					{
+						Number = chapter.Number.ToString(),
+						Label = chapter.PublishedChapterMarker,
+						Value = chapterContent
+					});
+				}
+				index.Bible.Add(outputBook);
+				downloadIndex.Data.Add(outPutBookDataInclude);
 
-            await Task.WhenAll(outputTasks);
-        }
-        /// <summary>
-        /// Load all USFM files in a directory inside of the ZipFileSystem
-        /// </summary>
-        /// <param name="directory">A ZipFileSystem to load from</param>
-        /// <returns>A list of USFM files</returns>
-        static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
-        {
-            USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
-            var output = new List<USFMDocument>();
-            foreach (var f in directory.GetAllFiles(".usfm"))
-            {
-                var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
-                // If we don't have an abbreviation then try to figure it out from the file name
-                var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
-                if(tableOfContentsMarkers.Count == 0)
-                {
-                    var bookAbbrivation = GetBookAbberviationFromFileName(f);
-                    if (bookAbbrivation != null)
-                    {
-                        tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbrivation });
-                    }
-                }
-                else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
-                {
-                    var bookAbbrivation = GetBookAbberviationFromFileName(f);
-                    if (bookAbbrivation != null)
-                    {
-                        tableOfContentsMarkers[0].BookAbbreviation = bookAbbrivation;
-                    }
-                }
-                output.Add(tmp);
-            }
-            return output;
-        }
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, abbreviation, "whole.json"), JsonSerializer.Serialize(outPutBookDataInclude)));
 
-        private static string GetBookAbberviationFromFileName(string f)
-        {
-            string bookAbbriviation = null;
-            var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
-            if (fileNameSplit.Length == 2)
-            {
-                if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
-                {
-                    bookAbbriviation = fileNameSplit[1].ToUpper();
-                }
-            }
-            else if (fileNameSplit.Length == 1)
-            {
-                if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
-                {
-                    bookAbbriviation = fileNameSplit[0].ToUpper();
-                }
-            }
+				// Since the print all page isn't going to broken up then just write stuff out here
+				printBuilder.AppendLine(content);
+			}
 
-            return bookAbbriviation;
-        }
-    }
+			// If we have something then create the print_all.html page and the index.html page
+			if (documents.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(index)));
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+
+
+			await Task.WhenAll(outputTasks);
+		}
+		/// <summary>
+		/// Load all USFM files in a directory inside of the ZipFileSystem
+		/// </summary>
+		/// <param name="directory">A ZipFileSystem to load from</param>
+		/// <returns>A list of USFM files</returns>
+		static async Task<List<USFMDocument>> LoadDirectoryAsync(ZipFileSystem directory)
+		{
+			USFMParser parser = new USFMParser(new List<string> { "s5" }, true);
+			var output = new List<USFMDocument>();
+			foreach (var f in directory.GetAllFiles(".usfm"))
+			{
+				var tmp = parser.ParseFromString(await directory.ReadAllTextAsync(f));
+				// If we don't have an abbreviation then try to figure it out from the file name
+				var tableOfContentsMarkers = tmp.GetChildMarkers<TOC3Marker>();
+				if (tableOfContentsMarkers.Count == 0)
+				{
+					var bookAbbrivation = GetBookAbberviationFromFileName(f);
+					if (bookAbbrivation != null)
+					{
+						tmp.Insert(new TOC3Marker() { BookAbbreviation = bookAbbrivation });
+					}
+				}
+				else if (Utils.GetBookNumber(tableOfContentsMarkers[0].BookAbbreviation) == 0)
+				{
+					var bookAbbrivation = GetBookAbberviationFromFileName(f);
+					if (bookAbbrivation != null)
+					{
+						tableOfContentsMarkers[0].BookAbbreviation = bookAbbrivation;
+					}
+				}
+				output.Add(tmp);
+			}
+			return output;
+		}
+
+		private static string GetBookAbberviationFromFileName(string f)
+		{
+			string bookAbbriviation = null;
+			var fileNameSplit = Path.GetFileNameWithoutExtension(f).Split('-');
+			if (fileNameSplit.Length == 2)
+			{
+				if (Utils.BibleBookOrder.Contains(fileNameSplit[1].ToUpper()))
+				{
+					bookAbbriviation = fileNameSplit[1].ToUpper();
+				}
+			}
+			else if (fileNameSplit.Length == 1)
+			{
+				if (Utils.BibleBookOrder.Contains(fileNameSplit[0].ToUpper()))
+				{
+					bookAbbriviation = fileNameSplit[0].ToUpper();
+				}
+			}
+
+			return bookAbbriviation;
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
@@ -14,186 +14,188 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-  internal class CommentaryRenderer
-  {
-    const string ChapterIdFormat = "chapter-{0}";
+	internal class CommentaryRenderer
+	{
+		const string ChapterIdFormat = "chapter-{0}";
 
-    public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
-    {
-      var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
-      var articles = LoadArticles(sourceDir, basePath);
-      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-      var outputTasks = new List<Task>();
-      var printStringBuilder = new StringBuilder();
-      var outputIndex = new OutputIndex()
-      {
-        TextDirection = textDirection,
-        LanguageCode = languageCode,
-        LanguageName = languageName,
-        ResourceType = "commentary",
-        ResourceTitle = heading,
-        RepoUrl = repoUrl,
-        Bible = new List<OutputBook>(),
-        Navigation = null,
-      };
-      var downloadIndex = new DownloadIndex()
-      {
-        Data = new List<OutputBook>()
-      };
-      foreach (var book in content)
-      {
-        var bookStringBuilder = new StringBuilder();
-        if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
-        {
-          Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-        }
+		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
+		{
+			var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
+			var articles = LoadArticles(sourceDir, basePath);
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			var outputTasks = new List<Task>();
+			var printStringBuilder = new StringBuilder();
+			var outputIndex = new OutputIndex()
+			{
+				TextDirection = textDirection,
+				LanguageCode = languageCode,
+				LanguageName = languageName,
+				ResourceType = "commentary",
+				ResourceTitle = heading,
+				RepoUrl = repoUrl,
+				Bible = new List<OutputBook>(),
+				Navigation = null,
+			};
+			var downloadIndex = new DownloadIndex();
+			foreach (var book in content)
+			{
+				var bookStringBuilder = new StringBuilder();
+				if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
+				{
+					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+				}
 
-        var outputBook = new OutputBook()
-        {
-          Label = book.Title,
-          Slug = book.BookId
-        };
-        var outPutBookDataIncluded = new OutputBook()
-        {
-          Label = book.Title,
-          Slug = book.BookId
-        };
+				var outputBook = new OutputBook()
+				{
+					Label = book.Title,
+					Slug = book.BookId
+				};
+				var bookWithContent = new OutputBook()
+				{
+					Label = book.Title,
+					Slug = book.BookId
+				};
 
-        foreach (var chapter in book.Chapters)
-        {
-          outputBook.Chapters.Add(new OutputChapters()
-          {
-            Label = chapter.Number,
-            Number = chapter.Number
-          });
-          RewriteLinks(chapter.Content);
-          bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat, chapter.Number))}\"></div>");
-          var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
-          outPutBookDataIncluded.Chapters.Add(new OutputChapters()
-          {
-            Label = chapter.Number,
-            Number = chapter.Number,
-            Value = renderedContent
-          });
-          bookStringBuilder.Append(renderedContent);
-          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
-          printStringBuilder.Append(renderedContent);
-        }
+				foreach (var chapter in book.Chapters)
+				{
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.Number,
+						Number = chapter.Number
+					});
+					RewriteLinks(chapter.Content);
+					bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat, chapter.Number))}\"></div>");
+					var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
+					var byteCount = System.Text.Encoding.UTF8.GetBytes(renderedContent).Length;
+					bookWithContent.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.Number,
+						Number = chapter.Number,
+						Content = renderedContent,
+						ByteCount = byteCount
+					});
+					bookStringBuilder.Append(renderedContent);
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
+					printStringBuilder.Append(renderedContent);
+				}
 
-        outputIndex.Bible.Add(outputBook);
-        downloadIndex.Data.Add(outPutBookDataIncluded);
-        // Add whole.json for each chapter for book level fetching
-        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
+				outputIndex.Bible.Add(outputBook);
+				downloadIndex.Content.Add(bookWithContent);
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(bookWithContent)));
+			}
 
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
 
+			// Add total bytes for someone to know how big the entire resource is
+			long totalByteCount = downloadIndex.Content
+					.SelectMany(outputBook => outputBook.Chapters)
+					.Sum(chapter => chapter.ByteCount);
+			downloadIndex.ByteCount = totalByteCount;
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
 
-      }
+			foreach (var (title, article) in articles)
+			{
+				RewriteLinks(article);
+				var tmpContent = Markdown.ToHtml(article, pipeline);
+				// Add articles to print copy
+				printStringBuilder.Append(tmpContent);
 
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"), tmpContent));
+			}
 
-      foreach (var (title, article) in articles)
-      {
-        RewriteLinks(article);
-        var tmpContent = Markdown.ToHtml(article, pipeline);
-        // Add articles to print copy
-        printStringBuilder.Append(tmpContent);
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
 
-        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"), tmpContent));
-      }
+			await Task.WhenAll(outputTasks);
+		}
 
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
+		/// <summary>
+		/// Change the md links to popup:// links
+		/// </summary>
+		/// <param name="input"></param>
+		/// <remarks>This modifies the input</remarks>
+		private void RewriteLinks(MarkdownDocument input)
+		{
+			foreach (var (id, link) in GetLinks(input))
+			{
+				link.Url = $"popup://{id}.html";
+			}
+		}
 
-      await Task.WhenAll(outputTasks);
-    }
+		private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
+		{
+			var output = new List<(string id, LinkInline link)>();
+			foreach (var link in input.Descendants<LinkInline>())
+			{
+				if (string.IsNullOrEmpty(link.Url))
+				{
+					continue;
+				}
 
-    /// <summary>
-    /// Change the md links to popup:// links
-    /// </summary>
-    /// <param name="input"></param>
-    /// <remarks>This modifies the input</remarks>
-    private void RewriteLinks(MarkdownDocument input)
-    {
-      foreach (var (id, link) in GetLinks(input))
-      {
-        link.Url = $"popup://{id}.html";
-      }
-    }
+				if (!link.Url.EndsWith(".md"))
+				{
+					continue;
+				}
 
-    private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
-    {
-      var output = new List<(string id, LinkInline link)>();
-      foreach (var link in input.Descendants<LinkInline>())
-      {
-        if (string.IsNullOrEmpty(link.Url))
-        {
-          continue;
-        }
+				if (!link.Url.StartsWith("../articles/"))
+				{
+					continue;
+				}
 
-        if (!link.Url.EndsWith(".md"))
-        {
-          continue;
-        }
+				output.Add((Path.GetFileNameWithoutExtension(link.Url), link));
+			}
+			return output;
+		}
 
-        if (!link.Url.StartsWith("../articles/"))
-        {
-          continue;
-        }
+		private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
+		{
+			var output = new List<CommentaryBook>(projects.Length);
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			foreach (var project in projects.OrderBy(p => p.sort))
+			{
+				var outputBook = new CommentaryBook()
+				{
+					Title = project.title,
+					BookId = project.identifier,
+				};
+				foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
+				{
+					outputBook.Chapters.Add(new CommentaryChapter()
+					{
+						Number = Path.GetFileNameWithoutExtension(chapter),
+						Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
+					});
+				}
+				output.Add(outputBook);
+			}
+			return output;
+		}
+		private Dictionary<string, MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
+		{
+			var output = new Dictionary<string, MarkdownDocument>();
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			foreach (var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"), ".md"))
+			{
+				output.Add(Path.GetFileNameWithoutExtension(article), Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
+			}
+			return output;
+		}
+		private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+		{
+			var chapters = input.ToList();
+			var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
+			foreach (var i in chapters)
+			{
+				var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
+				var tmpOrder = 0;
+				if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
+				{
+					continue;
+				}
+				tmp.Add((i, fileNameWithoutExtension, tmpOrder));
+			}
+			return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
+		}
 
-        output.Add((Path.GetFileNameWithoutExtension(link.Url), link));
-      }
-      return output;
-    }
-
-    private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
-    {
-      var output = new List<CommentaryBook>(projects.Length);
-      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-      foreach (var project in projects.OrderBy(p => p.sort))
-      {
-        var outputBook = new CommentaryBook()
-        {
-          Title = project.title,
-          BookId = project.identifier,
-        };
-        foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
-        {
-          outputBook.Chapters.Add(new CommentaryChapter()
-          {
-            Number = Path.GetFileNameWithoutExtension(chapter),
-            Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
-          });
-        }
-        output.Add(outputBook);
-      }
-      return output;
-    }
-    private Dictionary<string, MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
-    {
-      var output = new Dictionary<string, MarkdownDocument>();
-      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-      foreach (var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"), ".md"))
-      {
-        output.Add(Path.GetFileNameWithoutExtension(article), Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
-      }
-      return output;
-    }
-    private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-    {
-      var chapters = input.ToList();
-      var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
-      foreach (var i in chapters)
-      {
-        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
-        var tmpOrder = 0;
-        if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
-        {
-          continue;
-        }
-        tmp.Add((i, fileNameWithoutExtension, tmpOrder));
-      }
-      return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
-    }
-
-  }
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
@@ -14,186 +14,186 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-	internal class CommentaryRenderer
-	{
-		const string ChapterIdFormat = "chapter-{0}";
+  internal class CommentaryRenderer
+  {
+    const string ChapterIdFormat = "chapter-{0}";
 
-		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
-		{
-			var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
-			var articles = LoadArticles(sourceDir, basePath);
-			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-			var outputTasks = new List<Task>();
-			var printStringBuilder = new StringBuilder();
-			var outputIndex = new OutputIndex()
-			{
-				TextDirection = textDirection,
-				LanguageCode = languageCode,
-				LanguageName = languageName,
-				ResourceType = "commentary",
-				ResourceTitle = heading,
-				RepoUrl = repoUrl,
-				Bible = new List<OutputBook>(),
-				Navigation = null,
-			};
-			var downloadIndex = new DownloadIndex()
-			{
-				Data = new List<OutputBook>()
-			};
-			foreach (var book in content)
-			{
-				var bookStringBuilder = new StringBuilder();
-				if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
-				{
-					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-				}
+    public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
+    {
+      var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
+      var articles = LoadArticles(sourceDir, basePath);
+      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+      var outputTasks = new List<Task>();
+      var printStringBuilder = new StringBuilder();
+      var outputIndex = new OutputIndex()
+      {
+        TextDirection = textDirection,
+        LanguageCode = languageCode,
+        LanguageName = languageName,
+        ResourceType = "commentary",
+        ResourceTitle = heading,
+        RepoUrl = repoUrl,
+        Bible = new List<OutputBook>(),
+        Navigation = null,
+      };
+      var downloadIndex = new DownloadIndex()
+      {
+        Data = new List<OutputBook>()
+      };
+      foreach (var book in content)
+      {
+        var bookStringBuilder = new StringBuilder();
+        if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
+        {
+          Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+        }
 
-				var outputBook = new OutputBook()
-				{
-					Label = book.Title,
-					Slug = book.BookId
-				};
-				var outPutBookDataIncluded = new OutputBook()
-				{
-					Label = book.Title,
-					Slug = book.BookId
-				};
+        var outputBook = new OutputBook()
+        {
+          Label = book.Title,
+          Slug = book.BookId
+        };
+        var outPutBookDataIncluded = new OutputBook()
+        {
+          Label = book.Title,
+          Slug = book.BookId
+        };
 
-				foreach (var chapter in book.Chapters)
-				{
-					outputBook.Chapters.Add(new OutputChapters()
-					{
-						Label = chapter.Number,
-						Number = chapter.Number
-					});
-					RewriteLinks(chapter.Content);
-					bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat, chapter.Number))}\"></div>");
-					var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
-					outPutBookDataIncluded.Chapters.Add(new OutputChapters()
-					{
-						Label = chapter.Number,
-						Number = chapter.Number,
-						Value = renderedContent
-					});
-					bookStringBuilder.Append(renderedContent);
-					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
-					printStringBuilder.Append(renderedContent);
-				}
+        foreach (var chapter in book.Chapters)
+        {
+          outputBook.Chapters.Add(new OutputChapters()
+          {
+            Label = chapter.Number,
+            Number = chapter.Number
+          });
+          RewriteLinks(chapter.Content);
+          bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat, chapter.Number))}\"></div>");
+          var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
+          outPutBookDataIncluded.Chapters.Add(new OutputChapters()
+          {
+            Label = chapter.Number,
+            Number = chapter.Number,
+            Value = renderedContent
+          });
+          bookStringBuilder.Append(renderedContent);
+          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
+          printStringBuilder.Append(renderedContent);
+        }
 
-				outputIndex.Bible.Add(outputBook);
-				downloadIndex.Data.Add(outPutBookDataIncluded);
-				// Add whole.json for each chapter for book level fetching
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
+        outputIndex.Bible.Add(outputBook);
+        downloadIndex.Data.Add(outPutBookDataIncluded);
+        // Add whole.json for each chapter for book level fetching
+        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
 
 
 
-			}
+      }
 
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
 
-			foreach (var (title, article) in articles)
-			{
-				RewriteLinks(article);
-				var tmpContent = Markdown.ToHtml(article, pipeline);
-				// Add articles to print copy
-				printStringBuilder.Append(tmpContent);
+      foreach (var (title, article) in articles)
+      {
+        RewriteLinks(article);
+        var tmpContent = Markdown.ToHtml(article, pipeline);
+        // Add articles to print copy
+        printStringBuilder.Append(tmpContent);
 
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"), tmpContent));
-			}
+        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"), tmpContent));
+      }
 
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
 
-			await Task.WhenAll(outputTasks);
-		}
+      await Task.WhenAll(outputTasks);
+    }
 
-		/// <summary>
-		/// Change the md links to popup:// links
-		/// </summary>
-		/// <param name="input"></param>
-		/// <remarks>This modifies the input</remarks>
-		private void RewriteLinks(MarkdownDocument input)
-		{
-			foreach (var (id, link) in GetLinks(input))
-			{
-				link.Url = $"popup://{id}.html";
-			}
-		}
+    /// <summary>
+    /// Change the md links to popup:// links
+    /// </summary>
+    /// <param name="input"></param>
+    /// <remarks>This modifies the input</remarks>
+    private void RewriteLinks(MarkdownDocument input)
+    {
+      foreach (var (id, link) in GetLinks(input))
+      {
+        link.Url = $"popup://{id}.html";
+      }
+    }
 
-		private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
-		{
-			var output = new List<(string id, LinkInline link)>();
-			foreach (var link in input.Descendants<LinkInline>())
-			{
-				if (string.IsNullOrEmpty(link.Url))
-				{
-					continue;
-				}
+    private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
+    {
+      var output = new List<(string id, LinkInline link)>();
+      foreach (var link in input.Descendants<LinkInline>())
+      {
+        if (string.IsNullOrEmpty(link.Url))
+        {
+          continue;
+        }
 
-				if (!link.Url.EndsWith(".md"))
-				{
-					continue;
-				}
+        if (!link.Url.EndsWith(".md"))
+        {
+          continue;
+        }
 
-				if (!link.Url.StartsWith("../articles/"))
-				{
-					continue;
-				}
+        if (!link.Url.StartsWith("../articles/"))
+        {
+          continue;
+        }
 
-				output.Add((Path.GetFileNameWithoutExtension(link.Url), link));
-			}
-			return output;
-		}
+        output.Add((Path.GetFileNameWithoutExtension(link.Url), link));
+      }
+      return output;
+    }
 
-		private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
-		{
-			var output = new List<CommentaryBook>(projects.Length);
-			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-			foreach (var project in projects.OrderBy(p => p.sort))
-			{
-				var outputBook = new CommentaryBook()
-				{
-					Title = project.title,
-					BookId = project.identifier,
-				};
-				foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
-				{
-					outputBook.Chapters.Add(new CommentaryChapter()
-					{
-						Number = Path.GetFileNameWithoutExtension(chapter),
-						Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
-					});
-				}
-				output.Add(outputBook);
-			}
-			return output;
-		}
-		private Dictionary<string, MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
-		{
-			var output = new Dictionary<string, MarkdownDocument>();
-			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-			foreach (var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"), ".md"))
-			{
-				output.Add(Path.GetFileNameWithoutExtension(article), Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
-			}
-			return output;
-		}
-		private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-		{
-			var chapters = input.ToList();
-			var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
-			foreach (var i in chapters)
-			{
-				var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
-				var tmpOrder = 0;
-				if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
-				{
-					continue;
-				}
-				tmp.Add((i, fileNameWithoutExtension, tmpOrder));
-			}
-			return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
-		}
+    private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
+    {
+      var output = new List<CommentaryBook>(projects.Length);
+      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+      foreach (var project in projects.OrderBy(p => p.sort))
+      {
+        var outputBook = new CommentaryBook()
+        {
+          Title = project.title,
+          BookId = project.identifier,
+        };
+        foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
+        {
+          outputBook.Chapters.Add(new CommentaryChapter()
+          {
+            Number = Path.GetFileNameWithoutExtension(chapter),
+            Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
+          });
+        }
+        output.Add(outputBook);
+      }
+      return output;
+    }
+    private Dictionary<string, MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
+    {
+      var output = new Dictionary<string, MarkdownDocument>();
+      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+      foreach (var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"), ".md"))
+      {
+        output.Add(Path.GetFileNameWithoutExtension(article), Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
+      }
+      return output;
+    }
+    private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+    {
+      var chapters = input.ToList();
+      var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
+      foreach (var i in chapters)
+      {
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
+        var tmpOrder = 0;
+        if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
+        {
+          continue;
+        }
+        tmp.Add((i, fileNameWithoutExtension, tmpOrder));
+      }
+      return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
+    }
 
-	}
+  }
 }

--- a/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
@@ -14,165 +14,186 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-    internal class CommentaryRenderer
-    {
-        const string ChapterIdFormat = "chapter-{0}";
+	internal class CommentaryRenderer
+	{
+		const string ChapterIdFormat = "chapter-{0}";
 
-        public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
-        {
-            var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
-            var articles = LoadArticles(sourceDir, basePath);
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-            var outputTasks = new List<Task>();
-            var printStringBuilder = new StringBuilder();
-            var outputIndex = new OutputIndex()
-            {
-                TextDirection = textDirection,
-                LanguageCode = languageCode,
-                LanguageName = languageName,
-                ResourceType = "commentary",
-                ResourceTitle = heading,
-                RepoUrl = repoUrl,
-                Bible = new List<OutputBook>(),
-                Navigation = null,
-            };
-            foreach(var book in content)
-            {
-                var bookStringBuilder = new StringBuilder();
-                if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
-                {
-                    Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-                }
+		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
+		{
+			var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
+			var articles = LoadArticles(sourceDir, basePath);
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			var outputTasks = new List<Task>();
+			var printStringBuilder = new StringBuilder();
+			var outputIndex = new OutputIndex()
+			{
+				TextDirection = textDirection,
+				LanguageCode = languageCode,
+				LanguageName = languageName,
+				ResourceType = "commentary",
+				ResourceTitle = heading,
+				RepoUrl = repoUrl,
+				Bible = new List<OutputBook>(),
+				Navigation = null,
+			};
+			var downloadIndex = new DownloadIndex()
+			{
+				Data = new List<OutputBook>()
+			};
+			foreach (var book in content)
+			{
+				var bookStringBuilder = new StringBuilder();
+				if (!Directory.Exists(Path.Join(destinationDir, book.BookId)))
+				{
+					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+				}
 
-                var outputBook = new OutputBook()
-                {
-                    Label = book.Title,
-                    Slug = book.BookId
-                };
+				var outputBook = new OutputBook()
+				{
+					Label = book.Title,
+					Slug = book.BookId
+				};
+				var outPutBookDataIncluded = new OutputBook()
+				{
+					Label = book.Title,
+					Slug = book.BookId
+				};
 
-                foreach(var chapter in book.Chapters)
-                {
-                    outputBook.Chapters.Add(new OutputChapters()
-                    {
-                        Label = chapter.Number,
-                        Number = chapter.Number
-                    });
-                    RewriteLinks(chapter.Content);
-                    bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat,chapter.Number))}\"></div>");
-                    var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
-                    bookStringBuilder.Append(renderedContent);
-                    outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
-                    printStringBuilder.Append(renderedContent);
-                }
-                
-                outputIndex.Bible.Add(outputBook);
+				foreach (var chapter in book.Chapters)
+				{
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.Number,
+						Number = chapter.Number
+					});
+					RewriteLinks(chapter.Content);
+					bookStringBuilder.Append($"<div id=\"{(string.Format(ChapterIdFormat, chapter.Number))}\"></div>");
+					var renderedContent = Markdown.ToHtml(chapter.Content, pipeline);
+					outPutBookDataIncluded.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.Number,
+						Number = chapter.Number,
+						Value = renderedContent
+					});
+					bookStringBuilder.Append(renderedContent);
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.Number}.html"), renderedContent));
+					printStringBuilder.Append(renderedContent);
+				}
 
-            }
-            
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+				outputIndex.Bible.Add(outputBook);
+				downloadIndex.Data.Add(outPutBookDataIncluded);
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
 
-            foreach(var (title,article) in articles)
-            {
-                RewriteLinks(article);
-                var tmpContent = Markdown.ToHtml(article, pipeline);
-                // Add articles to print copy
-                printStringBuilder.Append(tmpContent);
 
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"),tmpContent));
-            }
 
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
+			}
 
-            await Task.WhenAll(outputTasks);
-        }
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
 
-        /// <summary>
-        /// Change the md links to popup:// links
-        /// </summary>
-        /// <param name="input"></param>
-        /// <remarks>This modifies the input</remarks>
-        private void RewriteLinks(MarkdownDocument input)
-        {
-            foreach(var (id, link) in GetLinks(input))
-            {
-                link.Url = $"popup://{id}.html";
-            }
-        }
+			foreach (var (title, article) in articles)
+			{
+				RewriteLinks(article);
+				var tmpContent = Markdown.ToHtml(article, pipeline);
+				// Add articles to print copy
+				printStringBuilder.Append(tmpContent);
 
-        private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
-        {
-            var output = new List<(string id, LinkInline link)>();
-            foreach (var link in input.Descendants<LinkInline>())
-            {
-                if (string.IsNullOrEmpty(link.Url))
-                {
-                    continue;
-                }
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, $"{title}.html"), tmpContent));
+			}
 
-                if (!link.Url.EndsWith(".md"))
-                {
-                    continue;
-                }
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printStringBuilder.ToString(), heading }))));
 
-                if (!link.Url.StartsWith("../articles/"))
-                {
-                    continue;
-                }
+			await Task.WhenAll(outputTasks);
+		}
 
-                output.Add((Path.GetFileNameWithoutExtension(link.Url),link));
-            }
-            return output;
-        }
+		/// <summary>
+		/// Change the md links to popup:// links
+		/// </summary>
+		/// <param name="input"></param>
+		/// <remarks>This modifies the input</remarks>
+		private void RewriteLinks(MarkdownDocument input)
+		{
+			foreach (var (id, link) in GetLinks(input))
+			{
+				link.Url = $"popup://{id}.html";
+			}
+		}
 
-        private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
-        {
-            var output = new List<CommentaryBook>(projects.Length);
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-            foreach (var project in projects.OrderBy(p => p.sort))
-            {
-                var outputBook = new CommentaryBook()
-                {
-                    Title = project.title,
-                    BookId = project.identifier,
-                };
-                foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
-                {
-                    outputBook.Chapters.Add(new CommentaryChapter()
-                    {
-                        Number = Path.GetFileNameWithoutExtension(chapter),
-                        Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
-                    });
-                }
-                output.Add(outputBook);
-            }
-            return output;
-        }
-        private Dictionary<string,MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
-        {
-            var output = new Dictionary<string,MarkdownDocument>();
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-            foreach(var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"),".md"))
-            {
-                output.Add(Path.GetFileNameWithoutExtension(article),Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
-            }
-            return output;
-        }
-        private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-        {
-            var chapters = input.ToList();
-            var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
-            foreach(var i in chapters)
-            {
-                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
-                var tmpOrder = 0;
-                if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
-                {
-                    continue;
-                }
-                tmp.Add((i,fileNameWithoutExtension,tmpOrder));
-            }
-            return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
-        }
+		private List<(string id, LinkInline link)> GetLinks(MarkdownDocument input)
+		{
+			var output = new List<(string id, LinkInline link)>();
+			foreach (var link in input.Descendants<LinkInline>())
+			{
+				if (string.IsNullOrEmpty(link.Url))
+				{
+					continue;
+				}
 
-    }
+				if (!link.Url.EndsWith(".md"))
+				{
+					continue;
+				}
+
+				if (!link.Url.StartsWith("../articles/"))
+				{
+					continue;
+				}
+
+				output.Add((Path.GetFileNameWithoutExtension(link.Url), link));
+			}
+			return output;
+		}
+
+		private List<CommentaryBook> LoadMarkdownFiles(ZipFileSystem sourceDir, string basePath, Project[] projects)
+		{
+			var output = new List<CommentaryBook>(projects.Length);
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			foreach (var project in projects.OrderBy(p => p.sort))
+			{
+				var outputBook = new CommentaryBook()
+				{
+					Title = project.title,
+					BookId = project.identifier,
+				};
+				foreach (var chapter in FilterAndOrderChapters(sourceDir.GetFiles(sourceDir.Join(basePath, project.path), ".md")))
+				{
+					outputBook.Chapters.Add(new CommentaryChapter()
+					{
+						Number = Path.GetFileNameWithoutExtension(chapter),
+						Content = Markdown.Parse(sourceDir.ReadAllText(chapter), pipeline)
+					});
+				}
+				output.Add(outputBook);
+			}
+			return output;
+		}
+		private Dictionary<string, MarkdownDocument> LoadArticles(ZipFileSystem sourceDir, string basePath)
+		{
+			var output = new Dictionary<string, MarkdownDocument>();
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+			foreach (var article in sourceDir.GetFiles(sourceDir.Join(basePath, "articles"), ".md"))
+			{
+				output.Add(Path.GetFileNameWithoutExtension(article), Markdown.Parse(sourceDir.ReadAllText(article), pipeline));
+			}
+			return output;
+		}
+		private IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+		{
+			var chapters = input.ToList();
+			var tmp = new List<(string fileName, string fileNameWithoutExtension, int Order)>(chapters.Count);
+			foreach (var i in chapters)
+			{
+				var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(i);
+				var tmpOrder = 0;
+				if (fileNameWithoutExtension != "intro" && !int.TryParse(fileNameWithoutExtension, out tmpOrder))
+				{
+					continue;
+				}
+				tmp.Add((i, fileNameWithoutExtension, tmpOrder));
+			}
+			return tmp.OrderBy(i => i.Order).Select(i => i.fileName);
+		}
+
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -14,196 +14,219 @@ using System.Threading.Tasks;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-    /// <summary>
-    /// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
-    /// </summary>
-    public abstract class ScripturalMarkdownRendererBase
-    {
-        protected abstract string VerseFormatString { get; }
-        protected abstract string ChapterFormatString { get; }
-        protected abstract string ContentType { get; }
-        protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
-        protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
-        protected string BuildFileName(string bookName)
-        {
-            return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
-        }
-        protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
-        {
-            return input
-                .Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
-                .Where(i => i.order != -1)
-                .OrderBy(i => i.order)
-                .Select(i => i.book);
-        }
-        protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-        {
-            return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
-        }
-        protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
-        {
-            return input
-                .Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
-                .Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
-                .OrderBy(i => i.index)
-                .Select(i => i.book);
-        }
-        protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
-        {
-            var splitLink = link.Split("/");
-            if (splitLink.Length == 1)
-            {
-                return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
-            }
+	/// <summary>
+	/// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
+	/// </summary>
+	public abstract class ScripturalMarkdownRendererBase
+	{
+		protected abstract string VerseFormatString { get; }
+		protected abstract string ChapterFormatString { get; }
+		protected abstract string ContentType { get; }
+		protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
+		protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
+		protected string BuildFileName(string bookName)
+		{
+			return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
+		}
+		protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
+		{
+			return input
+					.Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
+					.Where(i => i.order != -1)
+					.OrderBy(i => i.order)
+					.Select(i => i.book);
+		}
+		protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+		{
+			return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
+		}
+		protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
+		{
+			return input
+					.Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
+					.Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
+					.OrderBy(i => i.index)
+					.Select(i => i.book);
+		}
+		protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
+		{
+			var splitLink = link.Split("/");
+			if (splitLink.Length == 1)
+			{
+				return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
+			}
 
-            if (splitLink[0] == ".")
-            {
-                if (splitLink.Length == 2)
-                {
-                    return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
-                }
-            }
-            else if (splitLink[0] == "..")
-            {
-                if (splitLink.Length == 3)
-                {
-                    return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
-                }
-                else if (splitLink.Length == 4)
-                {
-                    return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
-                }
-            }
-            return link;
-        }
+			if (splitLink[0] == ".")
+			{
+				if (splitLink.Length == 2)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
+				}
+			}
+			else if (splitLink[0] == "..")
+			{
+				if (splitLink.Length == 3)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
+				}
+				else if (splitLink.Length == 4)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
+				}
+			}
+			return link;
+		}
 
-        protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
-        {
-            var output = new List<NavigationBook>(); 
-            foreach(var book in input)
-            {
-                var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
-                foreach(var chapter in book.Chapters)
-                {
-                    // Remove leading zeros from chapter
-                    string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
-                    navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString,book.BookId,chapter.ChapterNumber), title = printableChapterNumber });
-                }
-                output.Add(navBook);
-            }
-            return output;
-        }
+		protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
+		{
+			var output = new List<NavigationBook>();
+			foreach (var book in input)
+			{
+				var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
+				foreach (var chapter in book.Chapters)
+				{
+					// Remove leading zeros from chapter
+					string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
+					navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber), title = printableChapterNumber });
+				}
+				output.Add(navBook);
+			}
+			return output;
+		}
 
-        protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
-            string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
-        {
-            RCLinkOptions options = new RCLinkOptions()
-            {
-                BaseUser = userToRouteResourcesTo,
-                ServerUrl = baseUrl,
-                LanguageCode = languageCode
-                
-            };
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
-            var output = new List<TranslationMaterialsBook>();
+		protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
+				string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
+		{
+			RCLinkOptions options = new RCLinkOptions()
+			{
+				BaseUser = userToRouteResourcesTo,
+				ServerUrl = baseUrl,
+				LanguageCode = languageCode
 
-            foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
-            {
-                var tnBook = new TranslationMaterialsBook()
-                {
-                    FileName = BuildFileName(book),
-                    BookId = book,
-                    BookName = Utils.bookAbbrivationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbrivationMappingToEnglish[book.ToUpper()] : book,
-                };
+			};
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
+			var output = new List<TranslationMaterialsBook>();
 
-                var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
-                foreach(var chapter in FilterAndOrderChapters(chapters))
-                {
-                    var tnChapter = new TranslationMaterialsChapter(chapter);
-                    foreach(var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter),".md")))
-                    {
-                        var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
+			foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
+			{
+				var tnBook = new TranslationMaterialsBook()
+				{
+					FileName = BuildFileName(book),
+					BookId = book,
+					BookName = Utils.bookAbbrivationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbrivationMappingToEnglish[book.ToUpper()] : book,
+				};
 
-                        // adjust the heading blocks up one level so I can put in chapter and verse sections as H1
-                        foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
-                        {
-                            headingBlock.Level++;
-                        }
+				var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
+				foreach (var chapter in FilterAndOrderChapters(chapters))
+				{
+					var tnChapter = new TranslationMaterialsChapter(chapter);
+					foreach (var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter), ".md")))
+					{
+						var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
 
-                        foreach (var link in parsedVerse.Descendants<LinkInline>())
-                        {
-                            if (link.Url == null)
-                            {
-                                continue;
-                            }
-                            if (link.Url != null && link.Url.EndsWith(".md"))
-                            {
-                                link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
-                            }
-                        }
+						// adjust the heading blocks up one level so I can put in chapter and verse sections as H1
+						foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
+						{
+							headingBlock.Level++;
+						}
 
-                        var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
-                        tnChapter.Verses.Add(tnVerse);
-                    }
-                    tnBook.Chapters.Add(tnChapter);
-                }
-                output.Add(tnBook);
-            }
-            return output;
-        }
-        public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
-             Template printTemplate, string repoUrl, string heading, string baseUrl,
-            string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
-        {
-            var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
-            var printBuilder = new StringBuilder();
-            var outputTasks = new List<Task>();
-            var outputIndex = new OutputIndex()
-            {
-                LanguageCode = languageCode,
-                TextDirection = textDirection,
-                RepoUrl = repoUrl,
-                LanguageName = languageName,
-                ResourceType = ContentType,
-                ResourceTitle = heading,
-                Bible = new List<OutputBook>(),
-            };
-            foreach(var book in books)
-            {
-                var outputBook = new OutputBook()
-                {
-                    Label = book.BookName,
-                    Slug = book.BookId
-                };
-                foreach(var chapter in book.Chapters)
-                {
-                    var builder = new StringBuilder();
-                    BeforeChapter(builder, book, chapter);
-                    foreach (var verse in chapter.Verses)
-                    {
-                        BeforeVerse(builder, book, chapter, verse);
-                        builder.AppendLine(verse.HtmlContent);
-                    }
+						foreach (var link in parsedVerse.Descendants<LinkInline>())
+						{
+							if (link.Url == null)
+							{
+								continue;
+							}
+							if (link.Url != null && link.Url.EndsWith(".md"))
+							{
+								link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
+							}
+						}
 
-                    Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-                    outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builder.ToString()));
-                    printBuilder.Append(builder);
-                    outputBook.Chapters.Add(new OutputChapters()
-                    {
-                        Label = chapter.ChapterNumber,
-                        Number = chapter.ChapterNumber,
-                    });
-                }
-                outputIndex.Bible.Add(outputBook);
-            }
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+						var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
+						tnChapter.Verses.Add(tnVerse);
+					}
+					tnBook.Chapters.Add(tnChapter);
+				}
+				output.Add(tnBook);
+			}
+			return output;
+		}
+		public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
+				 Template printTemplate, string repoUrl, string heading, string baseUrl,
+				string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
+		{
+			var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var outputIndex = new OutputIndex()
+			{
+				LanguageCode = languageCode,
+				TextDirection = textDirection,
+				RepoUrl = repoUrl,
+				LanguageName = languageName,
+				ResourceType = ContentType,
+				ResourceTitle = heading,
+				Bible = new List<OutputBook>(),
+			};
+			var downloadIndex = new DownloadIndex()
+			{
+				Data = new List<OutputBook>()
+			};
+			foreach (var book in books)
+			{
+				var outputBook = new OutputBook()
+				{
+					Label = book.BookName,
+					Slug = book.BookId
+				};
+				var outPutBookDataIncluded = new OutputBook()
+				{
+					Slug = book.BookName,
+					Label = book.BookId
+				};
+				foreach (var chapter in book.Chapters)
+				{
+					var builder = new StringBuilder();
+					BeforeChapter(builder, book, chapter);
+					foreach (var verse in chapter.Verses)
+					{
+						BeforeVerse(builder, book, chapter, verse);
+						builder.AppendLine(verse.HtmlContent);
+					}
+					var builderContent = builder.ToString();
+					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builderContent));
+					printBuilder.Append(builder);
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.ChapterNumber,
+						Number = chapter.ChapterNumber,
+					});
+					outPutBookDataIncluded.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.ChapterNumber,
+						Number = chapter.ChapterNumber,
+						Value = builderContent
+					});
 
-            if (books.Count > 0)
-            {
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-            }
+				}
+				outputIndex.Bible.Add(outputBook);
+				downloadIndex.Data.Add(outPutBookDataIncluded);
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
 
-            await Task.WhenAll(outputTasks);
-        }
-    }
+
+			}
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+
+
+			if (books.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
+
+			await Task.WhenAll(outputTasks);
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -14,219 +14,223 @@ using System.Threading.Tasks;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-  /// <summary>
-  /// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
-  /// </summary>
-  public abstract class ScripturalMarkdownRendererBase
-  {
-    protected abstract string VerseFormatString { get; }
-    protected abstract string ChapterFormatString { get; }
-    protected abstract string ContentType { get; }
-    protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
-    protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
-    protected string BuildFileName(string bookName)
-    {
-      return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
-    }
-    protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
-    {
-      return input
-          .Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
-          .Where(i => i.order != -1)
-          .OrderBy(i => i.order)
-          .Select(i => i.book);
-    }
-    protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-    {
-      return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
-    }
-    protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
-    {
-      return input
-          .Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
-          .Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
-          .OrderBy(i => i.index)
-          .Select(i => i.book);
-    }
-    protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
-    {
-      var splitLink = link.Split("/");
-      if (splitLink.Length == 1)
-      {
-        return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
-      }
+	/// <summary>
+	/// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
+	/// </summary>
+	public abstract class ScripturalMarkdownRendererBase
+	{
+		protected abstract string VerseFormatString { get; }
+		protected abstract string ChapterFormatString { get; }
+		protected abstract string ContentType { get; }
+		protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
+		protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
+		protected string BuildFileName(string bookName)
+		{
+			return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
+		}
+		protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
+		{
+			return input
+					.Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
+					.Where(i => i.order != -1)
+					.OrderBy(i => i.order)
+					.Select(i => i.book);
+		}
+		protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+		{
+			return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
+		}
+		protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
+		{
+			return input
+					.Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
+					.Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
+					.OrderBy(i => i.index)
+					.Select(i => i.book);
+		}
+		protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
+		{
+			var splitLink = link.Split("/");
+			if (splitLink.Length == 1)
+			{
+				return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
+			}
 
-      if (splitLink[0] == ".")
-      {
-        if (splitLink.Length == 2)
-        {
-          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
-        }
-      }
-      else if (splitLink[0] == "..")
-      {
-        if (splitLink.Length == 3)
-        {
-          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
-        }
-        else if (splitLink.Length == 4)
-        {
-          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
-        }
-      }
-      return link;
-    }
+			if (splitLink[0] == ".")
+			{
+				if (splitLink.Length == 2)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
+				}
+			}
+			else if (splitLink[0] == "..")
+			{
+				if (splitLink.Length == 3)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
+				}
+				else if (splitLink.Length == 4)
+				{
+					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
+				}
+			}
+			return link;
+		}
 
-    protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
-    {
-      var output = new List<NavigationBook>();
-      foreach (var book in input)
-      {
-        var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
-        foreach (var chapter in book.Chapters)
-        {
-          // Remove leading zeros from chapter
-          string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
-          navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber), title = printableChapterNumber });
-        }
-        output.Add(navBook);
-      }
-      return output;
-    }
+		protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
+		{
+			var output = new List<NavigationBook>();
+			foreach (var book in input)
+			{
+				var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
+				foreach (var chapter in book.Chapters)
+				{
+					// Remove leading zeros from chapter
+					string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
+					navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber), title = printableChapterNumber });
+				}
+				output.Add(navBook);
+			}
+			return output;
+		}
 
-    protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
-        string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
-    {
-      RCLinkOptions options = new RCLinkOptions()
-      {
-        BaseUser = userToRouteResourcesTo,
-        ServerUrl = baseUrl,
-        LanguageCode = languageCode
+		protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
+				string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
+		{
+			RCLinkOptions options = new RCLinkOptions()
+			{
+				BaseUser = userToRouteResourcesTo,
+				ServerUrl = baseUrl,
+				LanguageCode = languageCode
 
-      };
-      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
-      var output = new List<TranslationMaterialsBook>();
+			};
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
+			var output = new List<TranslationMaterialsBook>();
 
-      foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
-      {
-        var tnBook = new TranslationMaterialsBook()
-        {
-          FileName = BuildFileName(book),
-          BookId = book,
-          BookName = Utils.bookAbbrivationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbrivationMappingToEnglish[book.ToUpper()] : book,
-        };
+			foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
+			{
+				var tnBook = new TranslationMaterialsBook()
+				{
+					FileName = BuildFileName(book),
+					BookId = book,
+					BookName = Utils.bookAbbreviationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbreviationMappingToEnglish[book.ToUpper()] : book,
+				};
 
-        var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
-        foreach (var chapter in FilterAndOrderChapters(chapters))
-        {
-          var tnChapter = new TranslationMaterialsChapter(chapter);
-          foreach (var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter), ".md")))
-          {
-            var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
+				var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
+				foreach (var chapter in FilterAndOrderChapters(chapters))
+				{
+					var tnChapter = new TranslationMaterialsChapter(chapter);
+					foreach (var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter), ".md")))
+					{
+						var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
 
-            // adjust the heading blocks up one level so I can put in chapter and verse sections as H1
-            foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
-            {
-              headingBlock.Level++;
-            }
+						// adjust the heading blocks up one level so I can put in chapter and verse sections as H1
+						foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
+						{
+							headingBlock.Level++;
+						}
 
-            foreach (var link in parsedVerse.Descendants<LinkInline>())
-            {
-              if (link.Url == null)
-              {
-                continue;
-              }
-              if (link.Url != null && link.Url.EndsWith(".md"))
-              {
-                link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
-              }
-            }
+						foreach (var link in parsedVerse.Descendants<LinkInline>())
+						{
+							if (link.Url == null)
+							{
+								continue;
+							}
+							if (link.Url != null && link.Url.EndsWith(".md"))
+							{
+								link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
+							}
+						}
 
-            var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
-            tnChapter.Verses.Add(tnVerse);
-          }
-          tnBook.Chapters.Add(tnChapter);
-        }
-        output.Add(tnBook);
-      }
-      return output;
-    }
-    public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
-         Template printTemplate, string repoUrl, string heading, string baseUrl,
-        string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
-    {
-      var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
-      var printBuilder = new StringBuilder();
-      var outputTasks = new List<Task>();
-      var outputIndex = new OutputIndex()
-      {
-        LanguageCode = languageCode,
-        TextDirection = textDirection,
-        RepoUrl = repoUrl,
-        LanguageName = languageName,
-        ResourceType = ContentType,
-        ResourceTitle = heading,
-        Bible = new List<OutputBook>(),
-      };
-      var downloadIndex = new DownloadIndex()
-      {
-        Data = new List<OutputBook>()
-      };
-      foreach (var book in books)
-      {
-        var outputBook = new OutputBook()
-        {
-          Label = book.BookName,
-          Slug = book.BookId
-        };
-        var outPutBookDataIncluded = new OutputBook()
-        {
-          Slug = book.BookName,
-          Label = book.BookId
-        };
-        foreach (var chapter in book.Chapters)
-        {
-          var builder = new StringBuilder();
-          BeforeChapter(builder, book, chapter);
-          foreach (var verse in chapter.Verses)
-          {
-            BeforeVerse(builder, book, chapter, verse);
-            builder.AppendLine(verse.HtmlContent);
-          }
-          var builderContent = builder.ToString();
-          Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builderContent));
-          printBuilder.Append(builder);
-          outputBook.Chapters.Add(new OutputChapters()
-          {
-            Label = chapter.ChapterNumber,
-            Number = chapter.ChapterNumber,
-          });
-          outPutBookDataIncluded.Chapters.Add(new OutputChapters()
-          {
-            Label = chapter.ChapterNumber,
-            Number = chapter.ChapterNumber,
-            Value = builderContent
-          });
+						var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
+						tnChapter.Verses.Add(tnVerse);
+					}
+					tnBook.Chapters.Add(tnChapter);
+				}
+				output.Add(tnBook);
+			}
+			return output;
+		}
+		public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
+				 Template printTemplate, string repoUrl, string heading, string baseUrl,
+				string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
+		{
+			var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var outputIndex = new OutputIndex()
+			{
+				LanguageCode = languageCode,
+				TextDirection = textDirection,
+				RepoUrl = repoUrl,
+				LanguageName = languageName,
+				ResourceType = ContentType,
+				ResourceTitle = heading,
+				Bible = new List<OutputBook>(),
+			};
+			var downloadIndex = new DownloadIndex();
+			foreach (var book in books)
+			{
+				var outputBook = new OutputBook()
+				{
+					Label = book.BookName,
+					Slug = book.BookId
+				};
+				var bookWithContent = new OutputBook()
+				{
+					Slug = book.BookName,
+					Label = book.BookId
+				};
+				foreach (var chapter in book.Chapters)
+				{
+					var builder = new StringBuilder();
+					BeforeChapter(builder, book, chapter);
+					foreach (var verse in chapter.Verses)
+					{
+						BeforeVerse(builder, book, chapter, verse);
+						builder.AppendLine(verse.HtmlContent);
+					}
+					var builderContent = builder.ToString();
+					var byteCount = System.Text.Encoding.UTF8.GetBytes(builderContent).Length;
+					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builderContent));
+					printBuilder.Append(builder);
+					outputBook.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.ChapterNumber,
+						Number = chapter.ChapterNumber,
+					});
+					bookWithContent.Chapters.Add(new OutputChapters()
+					{
+						Label = chapter.ChapterNumber,
+						Number = chapter.ChapterNumber,
+						Content = builderContent,
+						ByteCount = byteCount
+					});
 
-        }
-        outputIndex.Bible.Add(outputBook);
-        downloadIndex.Data.Add(outPutBookDataIncluded);
-        // Add whole.json for each chapter for book level fetching
-        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
-
-
-      }
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
-      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+				}
+				outputIndex.Bible.Add(outputBook);
+				downloadIndex.Content.Add(bookWithContent);
+				// Add whole.json for each chapter for book level fetching
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(bookWithContent)));
 
 
-      if (books.Count > 0)
-      {
-        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-      }
+			}
+			long totalByteCount = downloadIndex.Content
+				.SelectMany(outputBook => outputBook.Chapters)
+				.Sum(chapter => chapter.ByteCount);
+			downloadIndex.ByteCount = totalByteCount;
 
-      await Task.WhenAll(outputTasks);
-    }
-  }
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+
+
+			if (books.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
+
+			await Task.WhenAll(outputTasks);
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -14,219 +14,219 @@ using System.Threading.Tasks;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-	/// <summary>
-	/// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
-	/// </summary>
-	public abstract class ScripturalMarkdownRendererBase
-	{
-		protected abstract string VerseFormatString { get; }
-		protected abstract string ChapterFormatString { get; }
-		protected abstract string ContentType { get; }
-		protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
-		protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
-		protected string BuildFileName(string bookName)
-		{
-			return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
-		}
-		protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
-		{
-			return input
-					.Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
-					.Where(i => i.order != -1)
-					.OrderBy(i => i.order)
-					.Select(i => i.book);
-		}
-		protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
-		{
-			return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
-		}
-		protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
-		{
-			return input
-					.Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
-					.Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
-					.OrderBy(i => i.index)
-					.Select(i => i.book);
-		}
-		protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
-		{
-			var splitLink = link.Split("/");
-			if (splitLink.Length == 1)
-			{
-				return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
-			}
+  /// <summary>
+  /// A base renderer for Markdown files that have a Book-Chapter-Verse format such as tn and tq
+  /// </summary>
+  public abstract class ScripturalMarkdownRendererBase
+  {
+    protected abstract string VerseFormatString { get; }
+    protected abstract string ChapterFormatString { get; }
+    protected abstract string ContentType { get; }
+    protected abstract void BeforeVerse(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter, TranslationMaterialsVerse verse);
+    protected abstract void BeforeChapter(StringBuilder builder, TranslationMaterialsBook book, TranslationMaterialsChapter chapter);
+    protected string BuildFileName(string bookName)
+    {
+      return $"{Utils.GetBookNumber(bookName):00}-{bookName.ToUpper()}.html";
+    }
+    protected IEnumerable<string> FilterAndOrderBooks(IEnumerable<string> input)
+    {
+      return input
+          .Select(i => (book: i, order: Utils.BibleBookOrder.IndexOf(i.ToUpper())))
+          .Where(i => i.order != -1)
+          .OrderBy(i => i.order)
+          .Select(i => i.book);
+    }
+    protected IEnumerable<string> FilterAndOrderChapters(IEnumerable<string> input)
+    {
+      return input.Where(i => i == "front" || int.TryParse(i, out _)).Select(i => (file: i, order: i == "front" ? 0 : int.Parse(i))).OrderBy(i => i.order).Select(i => i.file);
+    }
+    protected IEnumerable<string> OrderVerses(IEnumerable<string> input)
+    {
+      return input
+          .Where(i => Path.GetFileName(i) == "intro.md" || int.TryParse(Path.GetFileNameWithoutExtension(i), out _))
+          .Select(i => (book: i, index: Path.GetFileName(i) == "intro.md" ? 0 : int.Parse(Path.GetFileNameWithoutExtension(i))))
+          .OrderBy(i => i.index)
+          .Select(i => i.book);
+    }
+    protected string RewriteContentLinks(string link, TranslationMaterialsBook currentBook, TranslationMaterialsChapter currentChapter)
+    {
+      var splitLink = link.Split("/");
+      if (splitLink.Length == 1)
+      {
+        return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[0][..^3]);
+      }
 
-			if (splitLink[0] == ".")
-			{
-				if (splitLink.Length == 2)
-				{
-					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
-				}
-			}
-			else if (splitLink[0] == "..")
-			{
-				if (splitLink.Length == 3)
-				{
-					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
-				}
-				else if (splitLink.Length == 4)
-				{
-					return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
-				}
-			}
-			return link;
-		}
+      if (splitLink[0] == ".")
+      {
+        if (splitLink.Length == 2)
+        {
+          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, currentChapter.ChapterNumber, splitLink[1][..^3]);
+        }
+      }
+      else if (splitLink[0] == "..")
+      {
+        if (splitLink.Length == 3)
+        {
+          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, currentBook.BookId, splitLink[1], splitLink[2][..^3]);
+        }
+        else if (splitLink.Length == 4)
+        {
+          return BuildFileName(currentBook.BookId) + "#" + string.Format(VerseFormatString, splitLink[1], splitLink[2], splitLink[3][..^3]);
+        }
+      }
+      return link;
+    }
 
-		protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
-		{
-			var output = new List<NavigationBook>();
-			foreach (var book in input)
-			{
-				var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
-				foreach (var chapter in book.Chapters)
-				{
-					// Remove leading zeros from chapter
-					string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
-					navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber), title = printableChapterNumber });
-				}
-				output.Add(navBook);
-			}
-			return output;
-		}
+    protected List<NavigationBook> BuildNavigation(List<TranslationMaterialsBook> input)
+    {
+      var output = new List<NavigationBook>();
+      foreach (var book in input)
+      {
+        var navBook = new NavigationBook() { abbreviation = book.BookId, file = book.FileName, title = book.BookName };
+        foreach (var chapter in book.Chapters)
+        {
+          // Remove leading zeros from chapter
+          string printableChapterNumber = chapter.ChapterNumber.TrimStart('0');
+          navBook.chapters.Add(new NavigationChapter() { id = string.Format(ChapterFormatString, book.BookId, chapter.ChapterNumber), title = printableChapterNumber });
+        }
+        output.Add(navBook);
+      }
+      return output;
+    }
 
-		protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
-				string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
-		{
-			RCLinkOptions options = new RCLinkOptions()
-			{
-				BaseUser = userToRouteResourcesTo,
-				ServerUrl = baseUrl,
-				LanguageCode = languageCode
+    protected virtual async Task<List<TranslationMaterialsBook>> LoadMarkDownFilesAsync(ZipFileSystem fileSystem,
+        string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
+    {
+      RCLinkOptions options = new RCLinkOptions()
+      {
+        BaseUser = userToRouteResourcesTo,
+        ServerUrl = baseUrl,
+        LanguageCode = languageCode
 
-			};
-			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
-			var output = new List<TranslationMaterialsBook>();
+      };
+      var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(options)).Build();
+      var output = new List<TranslationMaterialsBook>();
 
-			foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
-			{
-				var tnBook = new TranslationMaterialsBook()
-				{
-					FileName = BuildFileName(book),
-					BookId = book,
-					BookName = Utils.bookAbbrivationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbrivationMappingToEnglish[book.ToUpper()] : book,
-				};
+      foreach (var book in FilterAndOrderBooks(fileSystem.GetFolders(basePath)))
+      {
+        var tnBook = new TranslationMaterialsBook()
+        {
+          FileName = BuildFileName(book),
+          BookId = book,
+          BookName = Utils.bookAbbrivationMappingToEnglish.ContainsKey(book.ToUpper()) ? Utils.bookAbbrivationMappingToEnglish[book.ToUpper()] : book,
+        };
 
-				var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
-				foreach (var chapter in FilterAndOrderChapters(chapters))
-				{
-					var tnChapter = new TranslationMaterialsChapter(chapter);
-					foreach (var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter), ".md")))
-					{
-						var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
+        var chapters = fileSystem.GetFolders(fileSystem.Join(basePath, book));
+        foreach (var chapter in FilterAndOrderChapters(chapters))
+        {
+          var tnChapter = new TranslationMaterialsChapter(chapter);
+          foreach (var file in OrderVerses(fileSystem.GetFiles(fileSystem.Join(basePath, book, chapter), ".md")))
+          {
+            var parsedVerse = Markdown.Parse(await fileSystem.ReadAllTextAsync(file), pipeline);
 
-						// adjust the heading blocks up one level so I can put in chapter and verse sections as H1
-						foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
-						{
-							headingBlock.Level++;
-						}
+            // adjust the heading blocks up one level so I can put in chapter and verse sections as H1
+            foreach (var headingBlock in parsedVerse.Descendants<HeadingBlock>())
+            {
+              headingBlock.Level++;
+            }
 
-						foreach (var link in parsedVerse.Descendants<LinkInline>())
-						{
-							if (link.Url == null)
-							{
-								continue;
-							}
-							if (link.Url != null && link.Url.EndsWith(".md"))
-							{
-								link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
-							}
-						}
+            foreach (var link in parsedVerse.Descendants<LinkInline>())
+            {
+              if (link.Url == null)
+              {
+                continue;
+              }
+              if (link.Url != null && link.Url.EndsWith(".md"))
+              {
+                link.Url = RewriteContentLinks(link.Url, tnBook, tnChapter);
+              }
+            }
 
-						var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
-						tnChapter.Verses.Add(tnVerse);
-					}
-					tnBook.Chapters.Add(tnChapter);
-				}
-				output.Add(tnBook);
-			}
-			return output;
-		}
-		public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
-				 Template printTemplate, string repoUrl, string heading, string baseUrl,
-				string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
-		{
-			var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
-			var printBuilder = new StringBuilder();
-			var outputTasks = new List<Task>();
-			var outputIndex = new OutputIndex()
-			{
-				LanguageCode = languageCode,
-				TextDirection = textDirection,
-				RepoUrl = repoUrl,
-				LanguageName = languageName,
-				ResourceType = ContentType,
-				ResourceTitle = heading,
-				Bible = new List<OutputBook>(),
-			};
-			var downloadIndex = new DownloadIndex()
-			{
-				Data = new List<OutputBook>()
-			};
-			foreach (var book in books)
-			{
-				var outputBook = new OutputBook()
-				{
-					Label = book.BookName,
-					Slug = book.BookId
-				};
-				var outPutBookDataIncluded = new OutputBook()
-				{
-					Slug = book.BookName,
-					Label = book.BookId
-				};
-				foreach (var chapter in book.Chapters)
-				{
-					var builder = new StringBuilder();
-					BeforeChapter(builder, book, chapter);
-					foreach (var verse in chapter.Verses)
-					{
-						BeforeVerse(builder, book, chapter, verse);
-						builder.AppendLine(verse.HtmlContent);
-					}
-					var builderContent = builder.ToString();
-					Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
-					outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builderContent));
-					printBuilder.Append(builder);
-					outputBook.Chapters.Add(new OutputChapters()
-					{
-						Label = chapter.ChapterNumber,
-						Number = chapter.ChapterNumber,
-					});
-					outPutBookDataIncluded.Chapters.Add(new OutputChapters()
-					{
-						Label = chapter.ChapterNumber,
-						Number = chapter.ChapterNumber,
-						Value = builderContent
-					});
+            var tnVerse = new TranslationMaterialsVerse(Path.GetFileNameWithoutExtension(file), parsedVerse.ToHtml(pipeline));
+            tnChapter.Verses.Add(tnVerse);
+          }
+          tnBook.Chapters.Add(tnChapter);
+        }
+        output.Add(tnBook);
+      }
+      return output;
+    }
+    public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
+         Template printTemplate, string repoUrl, string heading, string baseUrl,
+        string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
+    {
+      var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
+      var printBuilder = new StringBuilder();
+      var outputTasks = new List<Task>();
+      var outputIndex = new OutputIndex()
+      {
+        LanguageCode = languageCode,
+        TextDirection = textDirection,
+        RepoUrl = repoUrl,
+        LanguageName = languageName,
+        ResourceType = ContentType,
+        ResourceTitle = heading,
+        Bible = new List<OutputBook>(),
+      };
+      var downloadIndex = new DownloadIndex()
+      {
+        Data = new List<OutputBook>()
+      };
+      foreach (var book in books)
+      {
+        var outputBook = new OutputBook()
+        {
+          Label = book.BookName,
+          Slug = book.BookId
+        };
+        var outPutBookDataIncluded = new OutputBook()
+        {
+          Slug = book.BookName,
+          Label = book.BookId
+        };
+        foreach (var chapter in book.Chapters)
+        {
+          var builder = new StringBuilder();
+          BeforeChapter(builder, book, chapter);
+          foreach (var verse in chapter.Verses)
+          {
+            BeforeVerse(builder, book, chapter, verse);
+            builder.AppendLine(verse.HtmlContent);
+          }
+          var builderContent = builder.ToString();
+          Directory.CreateDirectory(Path.Join(destinationDir, book.BookId));
+          outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, $"{chapter.ChapterNumber}.html"), builderContent));
+          printBuilder.Append(builder);
+          outputBook.Chapters.Add(new OutputChapters()
+          {
+            Label = chapter.ChapterNumber,
+            Number = chapter.ChapterNumber,
+          });
+          outPutBookDataIncluded.Chapters.Add(new OutputChapters()
+          {
+            Label = chapter.ChapterNumber,
+            Number = chapter.ChapterNumber,
+            Value = builderContent
+          });
 
-				}
-				outputIndex.Bible.Add(outputBook);
-				downloadIndex.Data.Add(outPutBookDataIncluded);
-				// Add whole.json for each chapter for book level fetching
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
-
-
-			}
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
-			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
+        }
+        outputIndex.Bible.Add(outputBook);
+        downloadIndex.Data.Add(outPutBookDataIncluded);
+        // Add whole.json for each chapter for book level fetching
+        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, book.BookId, "whole.json"), JsonSerializer.Serialize(outPutBookDataIncluded)));
 
 
-			if (books.Count > 0)
-			{
-				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-			}
+      }
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+      outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "download.json"), JsonSerializer.Serialize(downloadIndex)));
 
-			await Task.WhenAll(outputTasks);
-		}
-	}
+
+      if (books.Count > 0)
+      {
+        outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+      }
+
+      await Task.WhenAll(outputTasks);
+    }
+  }
 }


### PR DESCRIPTION
 This commit creates a download.json file type for the entire repository, and it creates book level "whole.json" files in each book.  
 - Bible
 - Commentary
 - notes
 - questions

This allows for downloading an entire repository into memory, such that it could be cached in teh browser or a service worker etc;  The main advantage to this json format instead of just a whole.html at the book or repository level is that the individual responses can be cached or accessed more granularly.   E.g, the entire bible can be requested in 1 request to blob storage vs 1000+ if desired. 

Edit: @PurpleGuitar .. just in case you didn't see this as well.