### PR TITLE
added lastRendered property to json indicies

### DIFF
--- a/ScriptureRenderingPipeline/Models/OutputBook.cs
+++ b/ScriptureRenderingPipeline/Models/OutputBook.cs
@@ -5,15 +5,18 @@ namespace ScriptureRenderingPipeline.Models;
 
 public class OutputBook
 {
-    [JsonPropertyName("slug")]
-    public string Slug { get; set; }
-    [JsonPropertyName("label")]
-    public string Label { get; set; }
-    [JsonPropertyName("chapters")]
-    public List<OutputChapters> Chapters { get; set; }
+	[JsonPropertyName("slug")]
+	public string Slug { get; set; }
+	[JsonPropertyName("label")]
+	public string Label { get; set; }
+	[JsonPropertyName("chapters")]
+	public List<OutputChapters> Chapters { get; set; }
 
-    public OutputBook()
-    {
-        Chapters = new List<OutputChapters>();
-    }
+	[JsonPropertyName("lastRendered")]
+	public string LastRendered { get; set; }
+
+	public OutputBook()
+	{
+		Chapters = new List<OutputChapters>();
+	}
 }

--- a/ScriptureRenderingPipeline/Models/OutputIndex.cs
+++ b/ScriptureRenderingPipeline/Models/OutputIndex.cs
@@ -5,25 +5,33 @@ namespace ScriptureRenderingPipeline.Models;
 
 public class OutputIndex
 {
-    [JsonPropertyName("languageName")]
-    public string LanguageName { get; set; }
-    [JsonPropertyName("languageCode")]
-    public string LanguageCode { get; set; }
-    [JsonPropertyName("resourceType")]
-    public string ResourceType { get; set; }
-    [JsonPropertyName("resourceTitle")]
-    public string ResourceTitle { get; set; }
-    [JsonPropertyName("textDirection")]
-    public string TextDirection { get; set; }
-    [JsonPropertyName("repoUrl")]
-    public string RepoUrl { get; set; }
-    [JsonPropertyName("bible")]
-    public List<OutputBook> Bible { get; set; }
-    [JsonPropertyName("words")]
-    public List<OutputWordCategory> Words { get; set; }
-    [JsonPropertyName("navigation")]
-    public List<OutputNavigation> Navigation { get; set; }
-    [JsonPropertyName("downloadLinks")]
-    public List<DownloadLink> DownloadLinks { get; set; }
+	[JsonPropertyName("languageName")]
+	public string LanguageName { get; set; }
+	[JsonPropertyName("languageCode")]
+	public string LanguageCode { get; set; }
+	[JsonPropertyName("resourceType")]
+	public string ResourceType { get; set; }
+	[JsonPropertyName("resourceTitle")]
+	public string ResourceTitle { get; set; }
+	[JsonPropertyName("textDirection")]
+	public string TextDirection { get; set; }
+	[JsonPropertyName("repoUrl")]
+	public string RepoUrl { get; set; }
+	[JsonPropertyName("bible")]
+	public List<OutputBook> Bible { get; set; }
+	[JsonPropertyName("words")]
+	public List<OutputWordCategory> Words { get; set; }
+	[JsonPropertyName("navigation")]
+	public List<OutputNavigation> Navigation { get; set; }
+	[JsonPropertyName("downloadLinks")]
+	public List<DownloadLink> DownloadLinks { get; set; }
+
+	[JsonPropertyName("lastRendered")]
+	public string LastRendered { get; set; }
+
+	[JsonPropertyName("wholeResourceByteCount")]
+	public long ByteCount { get; set; }
+
+
 
 }

--- a/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
+++ b/ScriptureRenderingPipeline/Models/OutputIndexDownload.cs
@@ -8,7 +8,10 @@ public class DownloadIndex
 	[JsonPropertyName("content")]
 	public List<OutputBook> Content { get; set; }
 
-	public long ByteCount { get; set; }
+
+
+	[JsonPropertyName("lastRendered")]
+	public string LastRendered { get; set; }
 
 	public DownloadIndex()
 	{


### PR DESCRIPTION
@rbnswartz  @PurpleGuitar 

This is one more additional PR on top of #61. (I merged 61 into dev, but not master, hence it's not killed yet).  I Just accidentally originally wrote that PR to master instead of develop.  I'll kill that when this is approved/when Read on Web is ready to consume it.  
These two commits do two things. 
1. Adds a lastRendered property to several models.   At the moment, I don't have any way of doing any sort of cache invalidation even if I wanted to for read on Web.  Adding a timestamp should enable cache invalidation if needed (which would be nice to put into the live reader since there is some measure of it caching things in its service worker.
2.  I added the total Byte count to the index.json file as well.  I realized it made more sense there than only in the download file.  That way someone can know how much is going to come across the wire if they do want to save the whole thing to their browser's cache. 