### PR TITLE
fix markdownRenderer downloadIndex label and slug being swapped

### DIFF
--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -184,8 +184,8 @@ namespace ScriptureRenderingPipeline.Renderers
 				};
 				var bookWithContent = new OutputBook()
 				{
-					Slug = book.BookName,
-					Label = book.BookId,
+					Label = book.BookName,
+					Slug = book.BookId,
 					LastRendered = lastRendered
 				};
 				foreach (var chapter in book.Chapters)


### PR DESCRIPTION
As you can see, I did a little copy paste wrong the other day on the markdown rendered and had the slug/label juxtaposed.  Quick fix for that. 