### PR TITLE
read apps directory to check for meta file to allow passing arbitrary meta info…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.DS_Store

--- a/ScriptureRenderingPipeline/Models/OutputIndex.cs
+++ b/ScriptureRenderingPipeline/Models/OutputIndex.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace ScriptureRenderingPipeline.Models;
@@ -33,5 +35,7 @@ public class OutputIndex
 	public long ByteCount { get; set; }
 
 
+	[JsonPropertyName("appMeta")]
+	public JsonElement AppMeta { get; set; }
 
 }

--- a/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/BibleRenderer.cs
@@ -4,6 +4,7 @@ using PipelineCommon.Helpers;
 using ScriptureRenderingPipeline.Helpers;
 using ScriptureRenderingPipeline.Models;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -33,7 +34,7 @@ namespace ScriptureRenderingPipeline.Renderers
 		/// <param name="textDirection">The direction of the script being used (either rtl or ltr)</param>
 		/// <param name="isBTTWriterProject">Whether or not this is a BTTWriter project</param>
 		/// <param name="languageCode">The language code for the project</param>
-		public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false)
+		public static async Task RenderAsync(ZipFileSystem source, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, string languageCode, string languageName, string textDirection, bool isBTTWriterProject = false, JsonElement appsMeta = new JsonElement())
 		{
 			List<USFMDocument> documents;
 			var downloadLinks = new List<DownloadLink>();
@@ -68,8 +69,10 @@ namespace ScriptureRenderingPipeline.Renderers
 				ResourceType = "bible",
 				Bible = new List<OutputBook>(),
 				DownloadLinks = downloadLinks,
-				LastRendered = lastRendered
+				LastRendered = lastRendered,
+				AppMeta = appsMeta
 			};
+
 			var downloadIndex = new DownloadIndex()
 			{
 				LastRendered = lastRendered

--- a/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/CommentaryRenderer.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using Markdig.Syntax.Inlines;
 using JsonSerializer = System.Text.Json.JsonSerializer;
+using System.Text.Json;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
@@ -18,7 +19,7 @@ namespace ScriptureRenderingPipeline.Renderers
 	{
 		const string ChapterIdFormat = "chapter-{0}";
 
-		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false)
+		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageName, string languageCode, bool isBTTWriterProject = false, JsonElement appsMeta = new JsonElement())
 		{
 			var content = LoadMarkdownFiles(sourceDir, basePath, resourceContainer.projects);
 			var articles = LoadArticles(sourceDir, basePath);
@@ -37,7 +38,8 @@ namespace ScriptureRenderingPipeline.Renderers
 				RepoUrl = repoUrl,
 				Bible = new List<OutputBook>(),
 				Navigation = null,
-				LastRendered = lastRendered
+				LastRendered = lastRendered,
+				AppMeta = appsMeta
 			};
 			var downloadIndex = new DownloadIndex()
 			{

--- a/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
+++ b/ScriptureRenderingPipeline/Renderers/ScripturalMarkdownRendererBase.cs
@@ -153,7 +153,7 @@ namespace ScriptureRenderingPipeline.Renderers
 		}
 		public virtual async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir,
 				 Template printTemplate, string repoUrl, string heading, string baseUrl,
-				string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
+				string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false, JsonElement appsMeta = new JsonElement())
 		{
 			var books = await LoadMarkDownFilesAsync(sourceDir, basePath, baseUrl, userToRouteResourcesTo, languageCode);
 			var printBuilder = new StringBuilder();
@@ -168,7 +168,8 @@ namespace ScriptureRenderingPipeline.Renderers
 				ResourceType = ContentType,
 				ResourceTitle = heading,
 				Bible = new List<OutputBook>(),
-				LastRendered = lastRendered
+				LastRendered = lastRendered,
+				AppMeta = appsMeta
 			};
 			var downloadIndex = new DownloadIndex()
 			{

--- a/ScriptureRenderingPipeline/Renderers/TranslationManualRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationManualRenderer.cs
@@ -17,254 +17,255 @@ using System.Text.Json;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-    public class TranslationManualRenderer
-    {
-        public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageCode, bool isBTTWriterProject = false)
-        {
-            // TODO: This needs to be converted from a hard-coded english string to something localized
-            var subtitleText = "This section answers the following question:";
-            var sections = await GetSectionsAsync(sourceDir, basePath, resourceContainer, baseUrl, userToRouteResourcesTo, languageCode);
-            var navigation = ConvertNavigation(sections);
-            var printBuilder = new StringBuilder();
-            var outputTasks = new List<Task>();
-            var outputIndex = new OutputIndex()
-            {
-                LanguageCode = languageCode,
-                LanguageName = "",
-                RepoUrl = repoUrl,
-                ResourceType = "tm",
-                ResourceTitle = heading,
-                TextDirection = textDirection,
-                Bible = null,
-                Words = null,
-                Navigation = navigation
-            };
-            foreach (var category in sections)
-            {
-                var titleMapping = new Dictionary<string, string>(category.Content.Count);
-                var builder = new StringBuilder();
-                builder.AppendLine($"<h1>{category.title}</h1>");
-                foreach (var content in category.Content)
-                {
-                    builder.AppendLine($"<div id=\"{content.slug}\"></div>");
-                    builder.AppendLine($"<h2>{content.title}</h2>");
+	public class TranslationManualRenderer
+	{
+		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template template, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageCode, bool isBTTWriterProject = false, JsonElement appsMeta = new JsonElement())
+		{
+			// TODO: This needs to be converted from a hard-coded english string to something localized
+			var subtitleText = "This section answers the following question:";
+			var sections = await GetSectionsAsync(sourceDir, basePath, resourceContainer, baseUrl, userToRouteResourcesTo, languageCode);
+			var navigation = ConvertNavigation(sections);
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var outputIndex = new OutputIndex()
+			{
+				LanguageCode = languageCode,
+				LanguageName = "",
+				RepoUrl = repoUrl,
+				ResourceType = "tm",
+				ResourceTitle = heading,
+				TextDirection = textDirection,
+				Bible = null,
+				Words = null,
+				Navigation = navigation,
+				AppMeta = appsMeta
+			};
+			foreach (var category in sections)
+			{
+				var titleMapping = new Dictionary<string, string>(category.Content.Count);
+				var builder = new StringBuilder();
+				builder.AppendLine($"<h1>{category.title}</h1>");
+				foreach (var content in category.Content)
+				{
+					builder.AppendLine($"<div id=\"{content.slug}\"></div>");
+					builder.AppendLine($"<h2>{content.title}</h2>");
 
-                    if (!string.IsNullOrEmpty(subtitleText))
-                    {
-                        builder.AppendLine($"<div>{subtitleText} {content.subtitle}</div>");
-                        builder.AppendLine($"<br/>");
-                    }
+					if (!string.IsNullOrEmpty(subtitleText))
+					{
+						builder.AppendLine($"<div>{subtitleText} {content.subtitle}</div>");
+						builder.AppendLine($"<br/>");
+					}
 
-                    builder.AppendLine(content.content);
+					builder.AppendLine(content.content);
 
-                    builder.AppendLine("<hr/>");
+					builder.AppendLine("<hr/>");
 
-                    titleMapping.Add(content.slug, content.title.TrimEnd());
-                }
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, BuildFileName(category)), builder.ToString()));
+					titleMapping.Add(content.slug, content.title.TrimEnd());
+				}
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, BuildFileName(category)), builder.ToString()));
 
-                printBuilder.Append(builder);
+				printBuilder.Append(builder);
 
-                // output mapping to file
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, Path.GetFileNameWithoutExtension(category.filename) + ".json"), JsonSerializer.Serialize(titleMapping )));
-            }
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+				// output mapping to file
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, Path.GetFileNameWithoutExtension(category.filename) + ".json"), JsonSerializer.Serialize(titleMapping)));
+			}
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
 
-            if (sections.Count > 0)
-            {
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-            }
+			if (sections.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
 
-            await Task.WhenAll(outputTasks);
-        }
-        private string BuildFileName(TranslationManualSection section)
-        {
-            return section.filename;
-        }
+			await Task.WhenAll(outputTasks);
+		}
+		private string BuildFileName(TranslationManualSection section)
+		{
+			return section.filename;
+		}
 
-        private List<OutputNavigation> ConvertNavigation(List<TranslationManualSection> sections)
-        {
-            var output = new List<OutputNavigation>(sections.Count);
-            foreach (var section in sections)
-            {
-                if (section.TableOfContents == null)
-                {
-                    continue;
-                }
-                var navigationSection = new OutputNavigation()
-                {
-                    File = BuildFileName(section),
-                    Label = section.title,
-                };
+		private List<OutputNavigation> ConvertNavigation(List<TranslationManualSection> sections)
+		{
+			var output = new List<OutputNavigation>(sections.Count);
+			foreach (var section in sections)
+			{
+				if (section.TableOfContents == null)
+				{
+					continue;
+				}
+				var navigationSection = new OutputNavigation()
+				{
+					File = BuildFileName(section),
+					Label = section.title,
+				};
 
-                var stack = new Stack<(TableOfContents tableOfContents, string fileName, bool lastChild, bool isTopLevel)>();
-                var parents = new Stack<OutputNavigation>();
-                parents.Push(navigationSection);
+				var stack = new Stack<(TableOfContents tableOfContents, string fileName, bool lastChild, bool isTopLevel)>();
+				var parents = new Stack<OutputNavigation>();
+				parents.Push(navigationSection);
 
-                stack.Push((section.TableOfContents, BuildFileName(section), false, true));
-                while (stack.Count > 0)
-                {
-                    var (tableOfContents, fileName, lastChild, isTopLevel) = stack.Pop();
-                    var currentItem = new OutputNavigation()
-                    {
-                        File = fileName,
-                        Label = tableOfContents.title,
-                        Slug = tableOfContents.link ?? ""
-                    };
-                    if (!isTopLevel)
-                    {
-                        parents.Peek().Children.Add(currentItem);
-                    }
-                    else
-                    {
-                        output.Add(currentItem);
-                    }
+				stack.Push((section.TableOfContents, BuildFileName(section), false, true));
+				while (stack.Count > 0)
+				{
+					var (tableOfContents, fileName, lastChild, isTopLevel) = stack.Pop();
+					var currentItem = new OutputNavigation()
+					{
+						File = fileName,
+						Label = tableOfContents.title,
+						Slug = tableOfContents.link ?? ""
+					};
+					if (!isTopLevel)
+					{
+						parents.Peek().Children.Add(currentItem);
+					}
+					else
+					{
+						output.Add(currentItem);
+					}
 
-                    if (lastChild)
-                    {
-                        parents.Pop();
-                    }
+					if (lastChild)
+					{
+						parents.Pop();
+					}
 
-                    if (tableOfContents.sections.Count == 0)
-                    {
-                        continue;
-                    }
-                    
-                    // Put it on the stack backwards so things end up in the right order
-                    for (var i = tableOfContents.sections.Count - 1; i >= 0; i--)
-                    {
-                        var itemIsLastChild = !isTopLevel && i == tableOfContents.sections.Count - 1;
-                        stack.Push((tableOfContents.sections[i], fileName, itemIsLastChild, false));
-                    }
-                    parents.Push(currentItem);
-                }
-            }
-            return output;
-        }
-        
-        private async Task<List<TranslationManualSection>> GetSectionsAsync(ZipFileSystem fileSystem, string basePath, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string languageCode)
-        {
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UsePipeTables()
-                .Use(new RCLinkExtension(new RCLinkOptions() { BaseUser = userToRouteResourcesTo, ServerUrl = baseUrl, LanguageCode = languageCode }))
-                .Build();
-            var output = new List<TranslationManualSection>();
-            var projects = resourceContainer.projects.OrderBy(p => p.sort);
-            foreach (var project in projects)
-            {
-                var section = new TranslationManualSection(project.title, project.path, Path.GetFileNameWithoutExtension(project.path) + ".html");
-                // Load table of contents
-                var tableOfContents = await LoadTableOfContentsAsync(fileSystem, fileSystem.Join(basePath, project.path));
-                section.TableOfContents = tableOfContents;
-                if (tableOfContents != null)
-                {
-                    var stack = new Stack<TableOfContents>(new[] { tableOfContents });
-                    while (stack.Count > 0)
-                    {
-                        var item = stack.Pop();
-                        if (item.link != null)
-                        {
-                            var path = fileSystem.JoinPath(basePath, project.path, item.link);
-                            var content = await GetContentAsync(fileSystem, path);
-                            if (content == null)
-                            {
-                                throw new Exception($"Missing content for {project.path}/{item.link}");
-                            }
-                            var markdown = Markdown.Parse(content, pipeline);
-                            foreach (var link in markdown.Descendants<LinkInline>())
-                            {
-                                if (link.Url == null)
-                                {
-                                    continue;
-                                }
-                                if (link.Url.EndsWith("01.md"))
-                                {
-                                    link.Url = RewriteContentLink(link.Url, section);
-                                }
-                            }
-                            section.Content.Add(new TranslationManualContent()
-                            {
-                                title = await GetTitleAsync(fileSystem, path),
-                                slug = item.link,
-                                subtitle = await GetSubTitleAsync(fileSystem, path),
-                                content = markdown.ToHtml(pipeline),
-                            });
-                        }
+					if (tableOfContents.sections.Count == 0)
+					{
+						continue;
+					}
 
-                        if (item.sections.Count != 0)
-                        {
-                            // Put it on the stack backwards so things end up in the right order
-                            for (var i = item.sections.Count - 1; i >= 0; i--)
-                            {
-                                stack.Push(item.sections[i]);
-                            }
-                        }
-                    }
-                }
-                output.Add(section);
-            }
-            return output;
-        }
+					// Put it on the stack backwards so things end up in the right order
+					for (var i = tableOfContents.sections.Count - 1; i >= 0; i--)
+					{
+						var itemIsLastChild = !isTopLevel && i == tableOfContents.sections.Count - 1;
+						stack.Push((tableOfContents.sections[i], fileName, itemIsLastChild, false));
+					}
+					parents.Push(currentItem);
+				}
+			}
+			return output;
+		}
 
-        private string RewriteContentLink(string link, TranslationManualSection currentSection)
-        {
-            var splitLink = link.Split("/");
-            if (splitLink[0] == "..")
-            {
-                if (splitLink.Length == 3)
-                {
-                    return currentSection.filename + "#" + splitLink[1];
-                }
-                else if (splitLink.Length == 5 || splitLink[1] == "..")
-                {
-                    return splitLink[2] + ".html#" + splitLink[3];
-                }
-            }
-            return link;
-        }
+		private async Task<List<TranslationManualSection>> GetSectionsAsync(ZipFileSystem fileSystem, string basePath, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string languageCode)
+		{
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UsePipeTables()
+					.Use(new RCLinkExtension(new RCLinkOptions() { BaseUser = userToRouteResourcesTo, ServerUrl = baseUrl, LanguageCode = languageCode }))
+					.Build();
+			var output = new List<TranslationManualSection>();
+			var projects = resourceContainer.projects.OrderBy(p => p.sort);
+			foreach (var project in projects)
+			{
+				var section = new TranslationManualSection(project.title, project.path, Path.GetFileNameWithoutExtension(project.path) + ".html");
+				// Load table of contents
+				var tableOfContents = await LoadTableOfContentsAsync(fileSystem, fileSystem.Join(basePath, project.path));
+				section.TableOfContents = tableOfContents;
+				if (tableOfContents != null)
+				{
+					var stack = new Stack<TableOfContents>(new[] { tableOfContents });
+					while (stack.Count > 0)
+					{
+						var item = stack.Pop();
+						if (item.link != null)
+						{
+							var path = fileSystem.JoinPath(basePath, project.path, item.link);
+							var content = await GetContentAsync(fileSystem, path);
+							if (content == null)
+							{
+								throw new Exception($"Missing content for {project.path}/{item.link}");
+							}
+							var markdown = Markdown.Parse(content, pipeline);
+							foreach (var link in markdown.Descendants<LinkInline>())
+							{
+								if (link.Url == null)
+								{
+									continue;
+								}
+								if (link.Url.EndsWith("01.md"))
+								{
+									link.Url = RewriteContentLink(link.Url, section);
+								}
+							}
+							section.Content.Add(new TranslationManualContent()
+							{
+								title = await GetTitleAsync(fileSystem, path),
+								slug = item.link,
+								subtitle = await GetSubTitleAsync(fileSystem, path),
+								content = markdown.ToHtml(pipeline),
+							});
+						}
 
-        private async Task<string> GetSubTitleAsync(ZipFileSystem fileSystem, string slugPath)
-        {
-            var path = fileSystem.Join(slugPath, "sub-title.md");
-            if (fileSystem.FileExists(path))
-            {
-                return await fileSystem.ReadAllTextAsync(path);
-            }
-            return null;
-        }
-        private async Task<string> GetTitleAsync(ZipFileSystem fileSystem, string slugPath)
-        {
-            var path = fileSystem.Join(slugPath, "title.md");
-            if (fileSystem.FileExists(path))
-            {
-                return await fileSystem.ReadAllTextAsync(path);
-            }
-            return null;
-        }
-        private async Task<string> GetContentAsync(ZipFileSystem fileSystem, string slugPath)
-        {
-            var path = fileSystem.Join(slugPath, "01.md");
-            if (fileSystem.FileExists(path))
-            {
-                return await fileSystem.ReadAllTextAsync(path);
-            }
-            return null;
-        }
-        private async Task<TableOfContents> LoadTableOfContentsAsync(ZipFileSystem fileSystem, string projectPath)
-        {
-            var path = fileSystem.Join(projectPath, "toc.yaml");
-            if (!fileSystem.FileExists(path))
-            {
-                return null;
-            }
-            try
-            {
-                var serializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
-                return serializer.Deserialize<TableOfContents>(await fileSystem.ReadAllTextAsync(path));
-            }
-            catch (Exception ex)
-            {
-                throw new Exception($"Unable to load table of contents for {path}", ex);
-            }
-        }
-    }
+						if (item.sections.Count != 0)
+						{
+							// Put it on the stack backwards so things end up in the right order
+							for (var i = item.sections.Count - 1; i >= 0; i--)
+							{
+								stack.Push(item.sections[i]);
+							}
+						}
+					}
+				}
+				output.Add(section);
+			}
+			return output;
+		}
+
+		private string RewriteContentLink(string link, TranslationManualSection currentSection)
+		{
+			var splitLink = link.Split("/");
+			if (splitLink[0] == "..")
+			{
+				if (splitLink.Length == 3)
+				{
+					return currentSection.filename + "#" + splitLink[1];
+				}
+				else if (splitLink.Length == 5 || splitLink[1] == "..")
+				{
+					return splitLink[2] + ".html#" + splitLink[3];
+				}
+			}
+			return link;
+		}
+
+		private async Task<string> GetSubTitleAsync(ZipFileSystem fileSystem, string slugPath)
+		{
+			var path = fileSystem.Join(slugPath, "sub-title.md");
+			if (fileSystem.FileExists(path))
+			{
+				return await fileSystem.ReadAllTextAsync(path);
+			}
+			return null;
+		}
+		private async Task<string> GetTitleAsync(ZipFileSystem fileSystem, string slugPath)
+		{
+			var path = fileSystem.Join(slugPath, "title.md");
+			if (fileSystem.FileExists(path))
+			{
+				return await fileSystem.ReadAllTextAsync(path);
+			}
+			return null;
+		}
+		private async Task<string> GetContentAsync(ZipFileSystem fileSystem, string slugPath)
+		{
+			var path = fileSystem.Join(slugPath, "01.md");
+			if (fileSystem.FileExists(path))
+			{
+				return await fileSystem.ReadAllTextAsync(path);
+			}
+			return null;
+		}
+		private async Task<TableOfContents> LoadTableOfContentsAsync(ZipFileSystem fileSystem, string projectPath)
+		{
+			var path = fileSystem.Join(projectPath, "toc.yaml");
+			if (!fileSystem.FileExists(path))
+			{
+				return null;
+			}
+			try
+			{
+				var serializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+				return serializer.Deserialize<TableOfContents>(await fileSystem.ReadAllTextAsync(path));
+			}
+			catch (Exception ex)
+			{
+				throw new Exception($"Unable to load table of contents for {path}", ex);
+			}
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Renderers/TranslationWordsRenderer.cs
+++ b/ScriptureRenderingPipeline/Renderers/TranslationWordsRenderer.cs
@@ -10,146 +10,148 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace ScriptureRenderingPipeline.Renderers
 {
-    public class TranslationWordsRenderer
-    {
-        public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false)
-        {
-            var projectPath = resourceContainer.projects[0].path;
-            var categories = await LoadWordsAsync(sourceDir, sourceDir.Join(basePath, projectPath), baseUrl, userToRouteResourcesTo, languageCode);
-            var printBuilder = new StringBuilder();
-            var outputTasks = new List<Task>();
-            var outputIndex = new OutputIndex()
-            {
-                LanguageCode = languageCode,
-                LanguageName = languageName,
-                TextDirection = textDirection,
-                RepoUrl = repoUrl,
-                ResourceType = "tw",
-                ResourceTitle = heading,
-                Bible = null,
-                Words = new List<OutputWordCategory>()
-            };
-            foreach(var category in categories )
-            {
-                var outputCategory = new OutputWordCategory()
-                {
-                    Slug = category.Slug,
-                    Label = category.Title
-                };
-                var titleMapping = new Dictionary<string, string>(category.Words.Count);
-                var builder = new StringBuilder();
-                builder.AppendLine($"<h1>{category.Title}</h1>");
-                foreach(var word in category.Words)
-                {
-                    builder.AppendLine($"<div id=\"{word.Slug}\"></div>");
-                    builder.AppendLine(word.Content);
-                    builder.AppendLine("<hr/>");
-                    titleMapping.Add(word.Slug, word.Title.Trim());
-                    outputCategory.Words.Add(new OutputWord()
-                    {
-                        Slug = word.Slug,
-                        Label = word.Title
-                    });
-                }
-                
-                outputIndex.Words.Add(outputCategory);
+	public class TranslationWordsRenderer
+	{
+		public async Task RenderAsync(ZipFileSystem sourceDir, string basePath, string destinationDir, Template printTemplate, string repoUrl, string heading, ResourceContainer resourceContainer, string baseUrl, string userToRouteResourcesTo, string textDirection, string languageCode, string languageName, bool isBTTWriterProject = false, JsonElement appsMeta = new JsonElement())
+		{
+			var projectPath = resourceContainer.projects[0].path;
+			var categories = await LoadWordsAsync(sourceDir, sourceDir.Join(basePath, projectPath), baseUrl, userToRouteResourcesTo, languageCode);
+			var printBuilder = new StringBuilder();
+			var outputTasks = new List<Task>();
+			var outputIndex = new OutputIndex()
+			{
+				LanguageCode = languageCode,
+				LanguageName = languageName,
+				TextDirection = textDirection,
+				RepoUrl = repoUrl,
+				ResourceType = "tw",
+				ResourceTitle = heading,
+				Bible = null,
+				Words = new List<OutputWordCategory>(),
+				AppMeta = appsMeta
+			};
+			foreach (var category in categories)
+			{
+				var outputCategory = new OutputWordCategory()
+				{
+					Slug = category.Slug,
+					Label = category.Title
+				};
+				var titleMapping = new Dictionary<string, string>(category.Words.Count);
+				var builder = new StringBuilder();
+				builder.AppendLine($"<h1>{category.Title}</h1>");
+				foreach (var word in category.Words)
+				{
+					builder.AppendLine($"<div id=\"{word.Slug}\"></div>");
+					builder.AppendLine(word.Content);
+					builder.AppendLine("<hr/>");
+					titleMapping.Add(word.Slug, word.Title.Trim());
+					outputCategory.Words.Add(new OutputWord()
+					{
+						Slug = word.Slug,
+						Label = word.Title
+					});
+				}
 
-                printBuilder.Append(builder);
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, BuildFileName(category.Slug)), builder.ToString()));
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, Path.GetFileNameWithoutExtension(BuildFileName(category.Slug)) + ".json"),JsonSerializer.Serialize(titleMapping)));
-            }
-            outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
+				outputIndex.Words.Add(outputCategory);
 
-            if (categories.Count > 0)
-            {
-                outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
-            }
+				printBuilder.Append(builder);
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, BuildFileName(category.Slug)), builder.ToString()));
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, Path.GetFileNameWithoutExtension(BuildFileName(category.Slug)) + ".json"), JsonSerializer.Serialize(titleMapping)));
+			}
+			outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "index.json"), JsonSerializer.Serialize(outputIndex)));
 
-            await Task.WhenAll(outputTasks);
-        }
+			if (categories.Count > 0)
+			{
+				outputTasks.Add(File.WriteAllTextAsync(Path.Join(destinationDir, "print_all.html"), printTemplate.Render(Hash.FromAnonymousObject(new { content = printBuilder.ToString(), heading }))));
+			}
 
-        private string RewriteContentLinks(string link, TranslationWordsCategory category)
-        {
-            var splitLink = link.Split("/");
-            if (splitLink.Length == 1)
-            {
-                return BuildFileName(category.Slug) + "#" + splitLink[0][..^3];
-            }
+			await Task.WhenAll(outputTasks);
+		}
 
-            if (splitLink[0] == ".")
-            {
-                return BuildFileName(category.Slug) + "#" + splitLink[1][..^3];
-            }
-            else if (splitLink[0] == "..")
-            {
-                if (splitLink.Length == 3)
-                {
-                    return BuildFileName(splitLink[1]) + "#" + splitLink[2][..^3];
-                }
-            }
-            return link;
-        }
+		private string RewriteContentLinks(string link, TranslationWordsCategory category)
+		{
+			var splitLink = link.Split("/");
+			if (splitLink.Length == 1)
+			{
+				return BuildFileName(category.Slug) + "#" + splitLink[0][..^3];
+			}
 
-        private string BuildFileName(string slug)
-        {
-            return $"{slug}.html";
-        }
-        private async Task<List<TranslationWordsCategory>> LoadWordsAsync(ZipFileSystem sourceDir, string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
-        {
-            var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(new RCLinkOptions()
-            {
-                BaseUser = userToRouteResourcesTo,
-                ServerUrl = baseUrl,
-                LanguageCode = languageCode,
-            })).Build();
-            var output = new List<TranslationWordsCategory>();
-            foreach( var dir in sourceDir.GetFolders(basePath))
-            {
-                if (Utils.TranslationWordsValidSections.Contains(dir))
-                {
-                    var category = new TranslationWordsCategory()
-                    {
-                        Slug = dir,
-                        Title = Utils.TranslationWordsTitleMapping[dir],
-                    };
+			if (splitLink[0] == ".")
+			{
+				return BuildFileName(category.Slug) + "#" + splitLink[1][..^3];
+			}
+			else if (splitLink[0] == "..")
+			{
+				if (splitLink.Length == 3)
+				{
+					return BuildFileName(splitLink[1]) + "#" + splitLink[2][..^3];
+				}
+			}
+			return link;
+		}
 
-                    foreach(var file in sourceDir.GetFiles(sourceDir.Join(basePath, dir),".md"))
-                    {
-                        var slug = Path.GetFileNameWithoutExtension(file);
-                        var content = Markdown.Parse(await sourceDir.ReadAllTextAsync(file), pipeline);
-                        var headings = content.Descendants<HeadingBlock>().ToList();
-                        var titleHeading = headings.FirstOrDefault(h => h.Level == 1);
+		private string BuildFileName(string slug)
+		{
+			return $"{slug}.html";
+		}
+		private async Task<List<TranslationWordsCategory>> LoadWordsAsync(ZipFileSystem sourceDir, string basePath, string baseUrl, string userToRouteResourcesTo, string languageCode)
+		{
+			var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Use(new RCLinkExtension(new RCLinkOptions()
+			{
+				BaseUser = userToRouteResourcesTo,
+				ServerUrl = baseUrl,
+				LanguageCode = languageCode,
+			})).Build();
+			var output = new List<TranslationWordsCategory>();
+			foreach (var dir in sourceDir.GetFolders(basePath))
+			{
+				if (Utils.TranslationWordsValidSections.Contains(dir))
+				{
+					var category = new TranslationWordsCategory()
+					{
+						Slug = dir,
+						Title = Utils.TranslationWordsTitleMapping[dir],
+					};
 
-                        foreach(var heading in headings)
-                        {
-                            heading.Level++;
-                        }
+					foreach (var file in sourceDir.GetFiles(sourceDir.Join(basePath, dir), ".md"))
+					{
+						var slug = Path.GetFileNameWithoutExtension(file);
+						var content = Markdown.Parse(await sourceDir.ReadAllTextAsync(file), pipeline);
+						var headings = content.Descendants<HeadingBlock>().ToList();
+						var titleHeading = headings.FirstOrDefault(h => h.Level == 1);
 
-                        foreach(var link in content.Descendants<LinkInline>())
-                        {
-                            if (link.Url != null && link.Url.EndsWith(".md"))
-                            {
-                                link.Url = RewriteContentLinks(link.Url, category);
-                            }
-                        }
+						foreach (var heading in headings)
+						{
+							heading.Level++;
+						}
 
-                        category.Words.Add(new TranslationWordsEntry()
-                        {
-                            Title = titleHeading?.Inline?.FirstChild?.ToString() ?? slug,
-                            Content = content.ToHtml(pipeline),
-                            Slug = slug,
-                        });
-                    }
-                    category.Words = category.Words.OrderBy(i => i.Title).ToList();
-                    output.Add(category);
-                }
-            }
-            return output;
-        }
-    }
+						foreach (var link in content.Descendants<LinkInline>())
+						{
+							if (link.Url != null && link.Url.EndsWith(".md"))
+							{
+								link.Url = RewriteContentLinks(link.Url, category);
+							}
+						}
+
+						category.Words.Add(new TranslationWordsEntry()
+						{
+							Title = titleHeading?.Inline?.FirstChild?.ToString() ?? slug,
+							Content = content.ToHtml(pipeline),
+							Slug = slug,
+						});
+					}
+					category.Words = category.Words.OrderBy(i => i.Title).ToList();
+					output.Add(category);
+				}
+			}
+			return output;
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Webhook.cs
+++ b/ScriptureRenderingPipeline/Webhook.cs
@@ -23,301 +23,326 @@ using ScriptureRenderingPipeline.Models;
 using PipelineCommon.Helpers;
 using System.Net.Http;
 using BTTWriterLib.Models;
+using System.Text.Json;
 
 namespace ScriptureRenderingPipeline
 {
-    public static class Webhook
-    {
-        [FunctionName("Webhook")]
-        public static async Task<IActionResult> RunAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "webhook")] HttpRequest req,
-            ILogger log)
-        {
-            var connectionString = Environment.GetEnvironmentVariable("ScripturePipelineStorageConnectionString");
-            var outputContainer = Environment.GetEnvironmentVariable("ScripturePipelineStorageOutputContainer");
-            var templateContainer = Environment.GetEnvironmentVariable("ScripturePipelineStorageTemplateContainer");
-            var baseUrl = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineBaseUrl");
-            var userToRouteResourcesTo = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineResourcesUser");
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            WebhookEvent webhookEvent = JsonConvert.DeserializeObject<WebhookEvent>(requestBody);
+	public static class Webhook
+	{
+		[FunctionName("Webhook")]
+		public static async Task<IActionResult> RunAsync(
+				[HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "webhook")] HttpRequest req,
+				ILogger log)
+		{
+			var connectionString = Environment.GetEnvironmentVariable("ScripturePipelineStorageConnectionString");
+			var outputContainer = Environment.GetEnvironmentVariable("ScripturePipelineStorageOutputContainer");
+			var templateContainer = Environment.GetEnvironmentVariable("ScripturePipelineStorageTemplateContainer");
+			var baseUrl = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineBaseUrl");
+			var userToRouteResourcesTo = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineResourcesUser");
+			string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+			WebhookEvent webhookEvent = JsonConvert.DeserializeObject<WebhookEvent>(requestBody);
 
-            DateTime timeStarted = DateTime.Now;
-
-
-            // validate
-
-            if (webhookEvent == null)
-            {
-                return new BadRequestObjectResult("Invalid webhook request");
-            }
-
-            if (req.Headers.ContainsKey("X-GitHub-Event"))
-            {
-                if (req.Headers["X-GitHub-Event"] != "push")
-                {
-                    return new OkObjectResult("Not converting because this isn't a push event");
-                }
-            }
-
-            if (webhookEvent.commits == null)
-            {
-                return new BadRequestObjectResult("Missing commits from webhook event");
-            }
-
-            log.LogInformation("Starting webhook for {repoName}", webhookEvent.repository.FullName);
-
-            // download repo
-
-            log.LogInformation($"Downloading repo");
-
-            using var httpClient = new HttpClient();
-            var downloadProjectPageTemplateTask = GetTemplateAsync(connectionString, templateContainer, "project-page.html");
-            var downloadPrintPageTemplateTask = GetTemplateAsync(connectionString, templateContainer, "print.html");
-            var result = await httpClient.GetAsync($"{webhookEvent.repository.HtmlUrl}/archive/master.zip");
-            if(result.StatusCode == HttpStatusCode.NotFound)
-            {
-                return new BadRequestObjectResult("Can't download source zip, probably an empty repo");
-            }
-            var zipStream = await result.Content.ReadAsStreamAsync();
-            var fileSystem = new ZipFileSystem(zipStream);
-
-            var repoType = RepoType.Unknown;
-            var isBTTWriterProject = false;
-            var outputDir = Utils.CreateTempFolder();
-            string exceptionMessage = null;
-            var title = "";
-            string template = null;
-            var converterUsed = "";
-            var languageName = string.Empty;
-            var resourceName = string.Empty;
-            var languageDirection = "ltr";
-            var languageCode = string.Empty;
-            try
-            {
-
-                // Determine type of repo
-                ResourceContainer resourceContainer = null;
-                var basePath = fileSystem.GetFolders().FirstOrDefault();
-                template = await downloadProjectPageTemplateTask;
-
-                if (fileSystem.FileExists(fileSystem.Join(basePath, "manifest.yaml")))
-                {
-                    log.LogInformation("Found manifest.yaml file");
-                    var reader = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
-                    try
-                    {
-                        resourceContainer = reader.Deserialize<ResourceContainer>(await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, "manifest.yaml")));
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception($"Error loading manifest.yaml {ex.Message}");
-                    }
-
-                    if (resourceContainer == null)
-                    {
-                        throw new Exception("Bad manifest file");
-                    }
-
-                    if (resourceContainer?.dublin_core?.identifier != null)
-                    {
-                        languageName = resourceContainer?.dublin_core?.language?.title;
-                        resourceName = resourceContainer?.dublin_core?.title;
-                        languageCode = resourceContainer?.dublin_core?.language?.identifier;
-                        languageDirection = resourceContainer?.dublin_core?.language?.direction;
-                        repoType = Utils.GetRepoType(resourceContainer?.dublin_core?.identifier);
-                    }
-                }
-                else if (fileSystem.FileExists(fileSystem.Join(basePath, "manifest.json")))
-                {
-                    isBTTWriterProject = true;
-                    log.LogInformation("Found BTTWriter project");
-                    BTTWriterManifest manifest;
-                    try
-                    {
-                        manifest = BTTWriterLoader.GetManifest(new ZipFileSystemBTTWriterLoader(fileSystem, basePath));
-                    }
-                    catch(Exception ex)
-                    {
-                        throw new Exception($"Error loading BTTWriter manifest: {ex.Message}", ex);
-                    }
-                    languageName = manifest?.target_language?.name;
-                    languageCode = manifest?.target_language?.id;
-                    resourceName = manifest?.resource?.name;
-                    languageDirection = manifest?.target_language?.direction;
-                    var resourceId = manifest?.resource?.id;
-                    if (string.IsNullOrEmpty(resourceName))
-                    {
-                        resourceName = resourceId;
-                    }
+			DateTime timeStarted = DateTime.Now;
 
 
-                    repoType = Utils.GetRepoType(resourceId);
-                }
-                else
-                {
-                    // Attempt to figure out what this is based on the name of the repo
-                    var split = webhookEvent.repository.Name.Split('_');
-                    if (split.Length > 1)
-                    {
-                        var retrieveLanguageTask = TranslationDatabaseInterface.GetLangagueAsync("https://td.unfoldingword.org/exports/langnames.json", split[0]);
-                        repoType = Utils.GetRepoType(split[1]);
-                        if (repoType == RepoType.Unknown)
-                        {
-                            if (Utils.BibleBookOrder.Contains(split[1].ToUpper()))
-                            {
-                                repoType = RepoType.Bible;
-                            }
-                        }
+			// validate
 
-                        var language = await retrieveLanguageTask;
-                        languageName = language?.LanguageName ?? split[0];
-                        languageCode = language?.LanguageCode ?? split[0];
-                        resourceName = repoType.ToString();
-                        languageDirection = language?.Direction;
-                    }
-                }
+			if (webhookEvent == null)
+			{
+				return new BadRequestObjectResult("Invalid webhook request");
+			}
 
-                if (repoType == RepoType.Unknown)
-                {
-                    throw new Exception("Unable to determine type of repo");
-                }
+			if (req.Headers.ContainsKey("X-GitHub-Event"))
+			{
+				if (req.Headers["X-GitHub-Event"] != "push")
+				{
+					return new OkObjectResult("Not converting because this isn't a push event");
+				}
+			}
 
-                title = BuildDisplayName(languageName, resourceName);
+			if (webhookEvent.commits == null)
+			{
+				return new BadRequestObjectResult("Missing commits from webhook event");
+			}
 
-                log.LogInformation("Starting render");
-                var printTemplate = await downloadPrintPageTemplateTask;
-                switch (repoType)
-                {
-                    case RepoType.Bible:
-                        converterUsed = isBTTWriterProject ? "Bible.BTTWriter" : "Bible.Normal";
-                        log.LogInformation("Rendering Bible");
-                        await BibleRenderer.RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, languageCode, languageName, languageDirection, isBTTWriterProject);
-                        break;
-                    case RepoType.translationNotes:
-                        if (resourceContainer == null)
-                        {
-                            throw new Exception("Can't render translationNotes without a manifest.");
-                        }
-                        converterUsed = isBTTWriterProject ? "translationNotes.BTTWriter" : "translationNotes.Normal";
-                        log.LogInformation("Rendering translationNotes");
-                        await new  TranslationNotesRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, baseUrl, userToRouteResourcesTo, languageDirection,  languageCode, languageName, isBTTWriterProject);
-                        break;
-                    case RepoType.translationQuestions:
-                        if (resourceContainer == null)
-                        {
-                            throw new Exception("Can't render translationQuestions without a manifest.");
-                        }
-                        converterUsed = isBTTWriterProject ? "translationQuestions.BTTWriter" : "translationQuestions.Normal";
-                        log.LogInformation("Rendering translationQuestions");
-                        await new TranslationQuestionsRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, languageName, isBTTWriterProject);
-                        break;
-                    case RepoType.translationWords:
-                        if (resourceContainer == null)
-                        {
-                            throw new Exception("Can't render translationWords without a manifest.");
-                        }
-                        converterUsed = isBTTWriterProject ? "translationWords.BTTWriter" : "translationWords.Normal";
-                        log.LogInformation("Rendering translationWords");
-                        await new TranslationWordsRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, languageName, isBTTWriterProject);
-                        break;
-                    case RepoType.translationAcademy:
-                        if (resourceContainer == null)
-                        {
-                            throw new Exception("Can't render translationManual/translationAcademy without a manifest.");
-                        }
-                        converterUsed = isBTTWriterProject ? "translationManual.BTTWriter" : "translationManual.Normal";
-                        log.LogInformation("Rendering translationManual");
-                        await new TranslationManualRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(template), Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, isBTTWriterProject);
-                        break;
-                    case RepoType.BibleCommentary:
-                        converterUsed = "bibleCommentary.Normal";
-                        log.LogInformation("Rendering Bible Commentary");
-                        await new CommentaryRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(template), Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageName, languageCode, isBTTWriterProject);
-                        break;
-                    default:
-                        throw new Exception($"Unable to render type {repoType}");
-                }
-            }
-            catch (Exception e)
-            {
-                log.LogError(e, e.Message);
-                exceptionMessage = e.Message;
-            }
+			log.LogInformation("Starting webhook for {repoName}", webhookEvent.repository.FullName);
 
-            // Create the build_log.json
-            BuildLog buildLog = new BuildLog()
-            {
-                success = string.IsNullOrEmpty(exceptionMessage),
-                ended_at = DateTime.Now,
-                created_at = timeStarted,
-                started_at = timeStarted,
-                convert_module = converterUsed,
-                lint_module = null,
-                status = string.IsNullOrEmpty(exceptionMessage) ? "success" : "failure",
-                repo_name = webhookEvent.repository.Name,
-                repo_owner = webhookEvent.repository.Owner.Username,
-                message = string.IsNullOrEmpty(exceptionMessage) ? "Conversion successful" : "Conversion failed",
-                warnings = Array.Empty<string>(),
-            };
-            if (webhookEvent.commits.Length != 0)
-            {
-                buildLog.commit_message = webhookEvent.commits[0].Message;
-                buildLog.committed_by = webhookEvent.commits[0].Committer.Username;
-                buildLog.commit_url = webhookEvent.commits[0].Url;
-                buildLog.commit_id = webhookEvent.commits[0].Id;
-            }
-            else
-            {
-                log.LogWarning("There were no commits in the push so not the information in the build_log.json won't have this");
-            }
+			// download repo
 
-            // Write build log
-            File.WriteAllText(Path.Join(outputDir, "build_log.json"), JsonConvert.SerializeObject(buildLog));
-            if (!string.IsNullOrEmpty(exceptionMessage))
-            {
-                string errorPage = "";
-                if (string.IsNullOrEmpty(template))
-                {
-                    errorPage = "<h1>Render Error</h1> Unable to load template so falling back to plain html <br/>" + exceptionMessage;
-                }
-                else
-                {
-                    errorPage = Template.Parse(template).Render(Hash.FromAnonymousObject( new { content="<h1>Render Error</h1> " + exceptionMessage }));
-                }
-                File.WriteAllText(Path.Join(outputDir, "index.html"), errorPage);
-            }
+			log.LogInformation($"Downloading repo");
 
-            log.LogInformation("Starting upload");
-            await Utils.UploadToStorage(log, connectionString, outputContainer, outputDir, $"/u/{webhookEvent.repository.Owner.Username}/{webhookEvent.repository.Name}");
+			using var httpClient = new HttpClient();
+			var downloadProjectPageTemplateTask = GetTemplateAsync(connectionString, templateContainer, "project-page.html");
+			var downloadPrintPageTemplateTask = GetTemplateAsync(connectionString, templateContainer, "print.html");
+			var result = await httpClient.GetAsync($"{webhookEvent.repository.HtmlUrl}/archive/master.zip");
+			if (result.StatusCode == HttpStatusCode.NotFound)
+			{
+				return new BadRequestObjectResult("Can't download source zip, probably an empty repo");
+			}
+			var zipStream = await result.Content.ReadAsStreamAsync();
+			var fileSystem = new ZipFileSystem(zipStream);
 
-            fileSystem.Close();
-            log.LogInformation("Cleaning up temporary files");
+			var repoType = RepoType.Unknown;
+			var isBTTWriterProject = false;
+			var outputDir = Utils.CreateTempFolder();
+			string exceptionMessage = null;
+			var title = "";
+			string template = null;
+			var converterUsed = "";
+			var languageName = string.Empty;
+			var resourceName = string.Empty;
+			var languageDirection = "ltr";
+			var languageCode = string.Empty;
+			JsonElement appsMeta = new JsonElement();
+			try
+			{
 
-            if (Directory.Exists(outputDir))
-            {
-                Directory.Delete(outputDir, true);
-            }
-            if (!string.IsNullOrEmpty(exceptionMessage))
-            {
-                return new BadRequestObjectResult(exceptionMessage);
-            }
-            return new OkResult();
-        }
+				// Determine type of repo
+				ResourceContainer resourceContainer = null;
+				var basePath = fileSystem.GetFolders().FirstOrDefault();
+				template = await downloadProjectPageTemplateTask;
 
-        private static string BuildDisplayName(string language, string resource)
-        {
-            return $"{language ?? "Unknown"}: {resource ?? "Unknown"}";
-        }
+				if (fileSystem.FileExists(fileSystem.Join(basePath, "manifest.yaml")))
+				{
+					log.LogInformation("Found manifest.yaml file");
+					var reader = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
+					try
+					{
+						resourceContainer = reader.Deserialize<ResourceContainer>(await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, "manifest.yaml")));
+					}
+					catch (Exception ex)
+					{
+						throw new Exception($"Error loading manifest.yaml {ex.Message}");
+					}
+
+					if (resourceContainer == null)
+					{
+						throw new Exception("Bad manifest file");
+					}
+
+					if (resourceContainer?.dublin_core?.identifier != null)
+					{
+						languageName = resourceContainer?.dublin_core?.language?.title;
+						resourceName = resourceContainer?.dublin_core?.title;
+						languageCode = resourceContainer?.dublin_core?.language?.identifier;
+						languageDirection = resourceContainer?.dublin_core?.language?.direction;
+						repoType = Utils.GetRepoType(resourceContainer?.dublin_core?.identifier);
+					}
+				}
+				else if (fileSystem.FileExists(fileSystem.Join(basePath, "manifest.json")))
+				{
+					isBTTWriterProject = true;
+					log.LogInformation("Found BTTWriter project");
+					BTTWriterManifest manifest;
+					try
+					{
+						manifest = BTTWriterLoader.GetManifest(new ZipFileSystemBTTWriterLoader(fileSystem, basePath));
+					}
+					catch (Exception ex)
+					{
+						throw new Exception($"Error loading BTTWriter manifest: {ex.Message}", ex);
+					}
+					languageName = manifest?.target_language?.name;
+					languageCode = manifest?.target_language?.id;
+					resourceName = manifest?.resource?.name;
+					languageDirection = manifest?.target_language?.direction;
+					var resourceId = manifest?.resource?.id;
+					if (string.IsNullOrEmpty(resourceName))
+					{
+						resourceName = resourceId;
+					}
 
 
-        private static async Task<string> GetTemplateAsync(string connectionString, string templateContainer, string templateFile)
-        {
-            BlobClient blobClient = new BlobClient(connectionString, templateContainer, templateFile);
-            MemoryStream templateStream = new MemoryStream();
-            await blobClient.DownloadToAsync(templateStream);
-            templateStream.Seek(0, SeekOrigin.Begin);
-            return await new StreamReader(templateStream).ReadToEndAsync();
-        }
+					repoType = Utils.GetRepoType(resourceId);
+				}
+				else
+				{
+					// Attempt to figure out what this is based on the name of the repo
+					var split = webhookEvent.repository.Name.Split('_');
+					if (split.Length > 1)
+					{
+						var retrieveLanguageTask = TranslationDatabaseInterface.GetLangagueAsync("https://td.unfoldingword.org/exports/langnames.json", split[0]);
+						repoType = Utils.GetRepoType(split[1]);
+						if (repoType == RepoType.Unknown)
+						{
+							if (Utils.BibleBookOrder.Contains(split[1].ToUpper()))
+							{
+								repoType = RepoType.Bible;
+							}
+						}
 
-    }
+						var language = await retrieveLanguageTask;
+						languageName = language?.LanguageName ?? split[0];
+						languageCode = language?.LanguageCode ?? split[0];
+						resourceName = repoType.ToString();
+						languageDirection = language?.Direction;
+					}
+				}
+
+				if (repoType == RepoType.Unknown)
+				{
+					throw new Exception("Unable to determine type of repo");
+				}
+
+				if (fileSystem.FileExists(fileSystem.Join(basePath, ".apps/meta.json")))
+				{
+
+					var jsonMeta = await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, ".apps/meta.json"));
+
+					if (IsValidJson(jsonMeta))
+					{
+						JsonDocument document = JsonDocument.Parse(jsonMeta);
+						JsonElement root = document.RootElement;
+						appsMeta = root;
+					}
+				}
+				title = BuildDisplayName(languageName, resourceName);
+
+				log.LogInformation("Starting render");
+				var printTemplate = await downloadPrintPageTemplateTask;
+				switch (repoType)
+				{
+					case RepoType.Bible:
+						converterUsed = isBTTWriterProject ? "Bible.BTTWriter" : "Bible.Normal";
+						log.LogInformation("Rendering Bible");
+						await BibleRenderer.RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, languageCode, languageName, languageDirection, isBTTWriterProject, appsMeta);
+						break;
+					case RepoType.translationNotes:
+						if (resourceContainer == null)
+						{
+							throw new Exception("Can't render translationNotes without a manifest.");
+						}
+						converterUsed = isBTTWriterProject ? "translationNotes.BTTWriter" : "translationNotes.Normal";
+						log.LogInformation("Rendering translationNotes");
+						await new TranslationNotesRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, languageName, isBTTWriterProject, appsMeta);
+						break;
+					case RepoType.translationQuestions:
+						if (resourceContainer == null)
+						{
+							throw new Exception("Can't render translationQuestions without a manifest.");
+						}
+						converterUsed = isBTTWriterProject ? "translationQuestions.BTTWriter" : "translationQuestions.Normal";
+						log.LogInformation("Rendering translationQuestions");
+						await new TranslationQuestionsRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, languageName, isBTTWriterProject, appsMeta);
+						break;
+					case RepoType.translationWords:
+						if (resourceContainer == null)
+						{
+							throw new Exception("Can't render translationWords without a manifest.");
+						}
+						converterUsed = isBTTWriterProject ? "translationWords.BTTWriter" : "translationWords.Normal";
+						log.LogInformation("Rendering translationWords");
+						await new TranslationWordsRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, languageName, isBTTWriterProject, appsMeta);
+						break;
+					case RepoType.translationAcademy:
+						if (resourceContainer == null)
+						{
+							throw new Exception("Can't render translationManual/translationAcademy without a manifest.");
+						}
+						converterUsed = isBTTWriterProject ? "translationManual.BTTWriter" : "translationManual.Normal";
+						log.LogInformation("Rendering translationManual");
+						await new TranslationManualRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(template), Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageCode, isBTTWriterProject, appsMeta);
+						break;
+					case RepoType.BibleCommentary:
+						converterUsed = "bibleCommentary.Normal";
+						log.LogInformation("Rendering Bible Commentary");
+						await new CommentaryRenderer().RenderAsync(fileSystem, basePath, outputDir, Template.Parse(template), Template.Parse(printTemplate), webhookEvent.repository.HtmlUrl, title, resourceContainer, baseUrl, userToRouteResourcesTo, languageDirection, languageName, languageCode, isBTTWriterProject, appsMeta);
+						break;
+					default:
+						throw new Exception($"Unable to render type {repoType}");
+				}
+			}
+			catch (Exception e)
+			{
+				log.LogError(e, e.Message);
+				exceptionMessage = e.Message;
+			}
+
+			// Create the build_log.json
+			BuildLog buildLog = new BuildLog()
+			{
+				success = string.IsNullOrEmpty(exceptionMessage),
+				ended_at = DateTime.Now,
+				created_at = timeStarted,
+				started_at = timeStarted,
+				convert_module = converterUsed,
+				lint_module = null,
+				status = string.IsNullOrEmpty(exceptionMessage) ? "success" : "failure",
+				repo_name = webhookEvent.repository.Name,
+				repo_owner = webhookEvent.repository.Owner.Username,
+				message = string.IsNullOrEmpty(exceptionMessage) ? "Conversion successful" : "Conversion failed",
+				warnings = Array.Empty<string>(),
+			};
+			if (webhookEvent.commits.Length != 0)
+			{
+				buildLog.commit_message = webhookEvent.commits[0].Message;
+				buildLog.committed_by = webhookEvent.commits[0].Committer.Username;
+				buildLog.commit_url = webhookEvent.commits[0].Url;
+				buildLog.commit_id = webhookEvent.commits[0].Id;
+			}
+			else
+			{
+				log.LogWarning("There were no commits in the push so not the information in the build_log.json won't have this");
+			}
+
+			// Write build log
+			File.WriteAllText(Path.Join(outputDir, "build_log.json"), JsonConvert.SerializeObject(buildLog));
+			if (!string.IsNullOrEmpty(exceptionMessage))
+			{
+				string errorPage = "";
+				if (string.IsNullOrEmpty(template))
+				{
+					errorPage = "<h1>Render Error</h1> Unable to load template so falling back to plain html <br/>" + exceptionMessage;
+				}
+				else
+				{
+					errorPage = Template.Parse(template).Render(Hash.FromAnonymousObject(new { content = "<h1>Render Error</h1> " + exceptionMessage }));
+				}
+				File.WriteAllText(Path.Join(outputDir, "index.html"), errorPage);
+			}
+
+			log.LogInformation("Starting upload");
+			await Utils.UploadToStorage(log, connectionString, outputContainer, outputDir, $"/u/{webhookEvent.repository.Owner.Username}/{webhookEvent.repository.Name}");
+
+			fileSystem.Close();
+			log.LogInformation("Cleaning up temporary files");
+
+			if (Directory.Exists(outputDir))
+			{
+				Directory.Delete(outputDir, true);
+			}
+			if (!string.IsNullOrEmpty(exceptionMessage))
+			{
+				return new BadRequestObjectResult(exceptionMessage);
+			}
+			return new OkResult();
+		}
+
+		private static string BuildDisplayName(string language, string resource)
+		{
+			return $"{language ?? "Unknown"}: {resource ?? "Unknown"}";
+		}
+
+
+		private static async Task<string> GetTemplateAsync(string connectionString, string templateContainer, string templateFile)
+		{
+			BlobClient blobClient = new BlobClient(connectionString, templateContainer, templateFile);
+			MemoryStream templateStream = new MemoryStream();
+			await blobClient.DownloadToAsync(templateStream);
+			templateStream.Seek(0, SeekOrigin.Begin);
+			return await new StreamReader(templateStream).ReadToEndAsync();
+		}
+		private static bool IsValidJson(string json)
+		{
+			try
+			{
+				JsonDocument.Parse(json);
+				return true;
+			}
+			catch (System.Text.Json.JsonException)
+			{
+				return false;
+			}
+		}
+	}
 }

--- a/ScriptureRenderingPipeline/Webhook.cs
+++ b/ScriptureRenderingPipeline/Webhook.cs
@@ -93,7 +93,7 @@ namespace ScriptureRenderingPipeline
 			var resourceName = string.Empty;
 			var languageDirection = "ltr";
 			var languageCode = string.Empty;
-			JsonElement appsMeta = new JsonElement();
+			var appsMeta = new JsonElement();
 			try
 			{
 
@@ -188,12 +188,15 @@ namespace ScriptureRenderingPipeline
 				{
 
 					var jsonMeta = await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, ".apps/scripture-rendering-pipeline/meta.json"));
-
-					if (IsValidJson(jsonMeta))
+					try
 					{
 						JsonDocument document = JsonDocument.Parse(jsonMeta);
 						JsonElement root = document.RootElement;
 						appsMeta = root;
+					}
+					catch (System.Text.Json.JsonException)
+					{
+						log.LogError("invalid json in the apps directory");
 					}
 				}
 				title = BuildDisplayName(languageName, resourceName);

--- a/ScriptureRenderingPipeline/Webhook.cs
+++ b/ScriptureRenderingPipeline/Webhook.cs
@@ -184,10 +184,10 @@ namespace ScriptureRenderingPipeline
 					throw new Exception("Unable to determine type of repo");
 				}
 
-				if (fileSystem.FileExists(fileSystem.Join(basePath, ".apps/meta.json")))
+				if (fileSystem.FileExists(fileSystem.Join(basePath, ".apps/scripture-rendering-pipeline/meta.json")))
 				{
 
-					var jsonMeta = await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, ".apps/meta.json"));
+					var jsonMeta = await fileSystem.ReadAllTextAsync(fileSystem.Join(basePath, ".apps/scripture-rendering-pipeline/meta.json"));
 
 					if (IsValidJson(jsonMeta))
 					{


### PR DESCRIPTION
In context of allowing a repo to specify additional metadata concerning itself, (and specifically a web font in this case):

This PR: 
1. When downloading the container, checks for the existence of a .apps/meta.json. (this is new territory in the sense that the RC spec allows for the .app directory.  I didn't see it say much on how things should be structured inside, so this was my stab at creating a convention for it).  [See](https://github.com/WycliffeAssociates/ScriptureRenderingPipeline/commit/8b411be6a6654ec9aed1d35b9b845510fa9cfd32?diff=split#diff-2d52460d3697317bf794d0728522210234e892ce62334c6a4c7543ffcbacc421R187-R198)
2. It validates that the json file is indeed valid json. [See](https://github.com/WycliffeAssociates/ScriptureRenderingPipeline/commit/8b411be6a6654ec9aed1d35b9b845510fa9cfd32?diff=split#diff-2d52460d3697317bf794d0728522210234e892ce62334c6a4c7543ffcbacc421R335-R347
)
3. It places that onto the output Index as for each renderer: [See](https://github.com/WycliffeAssociates/ScriptureRenderingPipeline/commit/8b411be6a6654ec9aed1d35b9b845510fa9cfd32?diff=split#diff-eccb3c0626d1391681e24e6f0f99fde03c0eee94c6ffe29f06be39b02e0ae75aR38-R39)

This data is consumed by ROW in [This PR](https://github.com/WycliffeAssociates/read.bibleineverylanguage.org/pull/10)

@PurpleGuitar  - Wasn't sure if you wanted to tag Reuben or not. 
@jsarabia  - tagging you to double check and make you think this isn't isn't a misuse to the .apps director or how its structured before we sent a new precedent for putting new metadata into a wacs repo. Here is where I put the data in.
[Wacs example Here](https://content.bibletranslationtools.org/Will_Kelly/ur_2th_text_ulb/src/branch/master/.apps)