### PR TITLE
adjust repoRendered to use fileBase instead of full path to save byte…

### DIFF
--- a/PipelineCommon/Models/BusMessages/RenderingResultMessage.cs
+++ b/PipelineCommon/Models/BusMessages/RenderingResultMessage.cs
@@ -18,6 +18,7 @@ public class RenderingResultMessage
 	
 	public int RepoId { get; set; }
 	public List<RenderedFile> RenderedFiles { get; set; } = new List<RenderedFile>();
+	public string FileBase { get; set; }
 	
 	public Dictionary<string,string> Titles { get; set; } = new Dictionary<string, string>();
 

--- a/PipelineCommon/Models/BusMessages/RenderingResultMessage.cs
+++ b/PipelineCommon/Models/BusMessages/RenderingResultMessage.cs
@@ -18,7 +18,7 @@ public class RenderingResultMessage
 	
 	public int RepoId { get; set; }
 	public List<RenderedFile> RenderedFiles { get; set; } = new List<RenderedFile>();
-	public string FileBase { get; set; }
+	public string FileBasePath { get; set; }
 	
 	public Dictionary<string,string> Titles { get; set; } = new Dictionary<string, string>();
 

--- a/SRPTests/FileTrackingLoggerTests.cs
+++ b/SRPTests/FileTrackingLoggerTests.cs
@@ -23,7 +23,7 @@ public class FileTrackingLoggerTests
         Assert.AreEqual(1, logger.Errors.Count);
         Assert.AreEqual(errorText, logger.Errors[0]);
         Assert.AreEqual(1, logger.Files.Count);
-        Assert.AreEqual("https://read.bibletranslationtools.org/test.txt", logger.Files[0].Path);
+        Assert.AreEqual("/test.txt", logger.Files[0].Path);
         Assert.AreEqual(content.Length, logger.Files[0].Size);
         Assert.AreEqual("txt", logger.Files[0].FileType);
         // Check that the hash for the content matches what we expect

--- a/ScriptureRenderingPipelineWorker/FileTrackingLogger.cs
+++ b/ScriptureRenderingPipelineWorker/FileTrackingLogger.cs
@@ -7,7 +7,7 @@ namespace ScriptureRenderingPipelineWorker;
 public class FileTrackingLogger: IRenderLogger
 {
     private readonly RepoType _type;
-    private string BaseUrl { get; } 
+    public string BaseUrl { get; } 
     public List<string> Warnings { get; } = new();
     public List<string> Errors { get; } = new();
     public List<RenderedFile> Files { get; } = new();
@@ -34,7 +34,7 @@ public class FileTrackingLogger: IRenderLogger
         var bytes = System.Text.Encoding.UTF8.GetBytes(content);
         var tmp = new RenderedFile()
         {
-            Path = $"{BaseUrl.TrimEnd('/')}/{path}".Replace("\\", "/"),
+            Path = $"/{path}".Replace("\\", "/"),
             Size = bytes.Length,
             FileType = Path.GetExtension(path).TrimStart('.'),
             Hash = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(bytes))

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -236,7 +236,7 @@ public class RenderingTrigger
 			    _ => "unknown"
 		    },
 		    RenderedFiles = fileTracker?.Files,
-				FileBase = fileTracker?.BaseUrl
+				FileBase = fileTracker?.BaseUrl,
 		    Titles = fileTracker?.Titles
 	    };
     }

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -236,7 +236,7 @@ public class RenderingTrigger
 			    _ => "unknown"
 		    },
 		    RenderedFiles = fileTracker?.Files,
-				FileBase = fileTracker?.BaseUrl,
+				FileBasePath = fileTracker?.BaseUrl,
 		    Titles = fileTracker?.Titles
 	    };
     }

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -88,6 +88,7 @@ public class RenderingTrigger
 	    {
 		    BaseUrl = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineBaseUrl"),
 		    UserToRouteResourcesTo = Environment.GetEnvironmentVariable("ScriptureRenderingPipelineResourcesUser"),
+				RepoUrl = message.RepoHtmlUrl
 	    };
 
 
@@ -235,6 +236,7 @@ public class RenderingTrigger
 			    _ => "unknown"
 		    },
 		    RenderedFiles = fileTracker?.Files,
+				FileBase = fileTracker?.BaseUrl
 		    Titles = fileTracker?.Titles
 	    };
     }


### PR DESCRIPTION
- adjust repoRendered to use fileBase instead of full path to save bytes.  
- pass along repo url

If this implementation still results in dropping some messages due to being too large (I couldn't test, but should shave about 20% of all messages with renderedFiles), then we'll have to do something else. 