### PR TITLE
Fix default branch not being honored

### DIFF
--- a/BTTWriterCatalog/Webhook.cs
+++ b/BTTWriterCatalog/Webhook.cs
@@ -300,7 +300,7 @@ namespace BTTWriterCatalog
             log.LogInformation($"Downloading repo");
             var blobServiceClient = new BlobServiceClient(Environment.GetEnvironmentVariable("BlobStorageConnectionString"));
 
-            var httpStream = await Utils.httpClient.GetStreamAsync($"{webhookEvent.repository.HtmlUrl}/archive/master.zip");
+            var httpStream = await Utils.httpClient.GetStreamAsync($"{webhookEvent.repository.HtmlUrl}/archive/{webhookEvent.repository?.default_branch ?? "master"}.zip");
             var zipStream = new MemoryStream();
             await httpStream.CopyToAsync(zipStream);
             var fileSystem = new ZipFileSystem(zipStream);


### PR DESCRIPTION
This pull request includes a change to the `BTTWriterCatalog/Webhook.cs` file to improve the handling of repository branch downloads. The most important change is:

* Modified the URL used for downloading the repository archive to dynamically use the repository's default branch instead of hardcoding "master". (`BTTWriterCatalog/Webhook.cs`)