### PR TITLE
wrap commentary html fragments with html minimum for a document

### DIFF
--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -34,8 +34,7 @@ This is the intro";
 <p>This is the intro</p>
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
-This is the article";
-    SanitizeNewlines(); 
+This is the article".SanitizeNewlines(); 
     
     [Test]
     public async Task TestWithNothing()

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -45,7 +45,7 @@ This is the article";
     <p>This is the article</p>
     </body>
     </html>
-".SanitizeNewlines();
+".SanitizeNewlines()
     
     [Test]
     public async Task TestWithNothing()

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -7,6 +7,8 @@ using PipelineCommon.Models.ResourceContainer;
 using ScriptureRenderingPipelineWorker.Models;
 using ScriptureRenderingPipelineWorker.Renderers;
 using SRPTests.TestHelpers;
+using System.Text.RegularExpressions;
+
 
 namespace SRPTests;
 
@@ -33,19 +35,7 @@ This is the intro";
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
 This is the article";
-    private string ExpectedArticleOutput = @"
-    <html lang=""en"">
-    <head>
-    <meta charset=""UTF-8"">
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
-    <title>article</title>
-    </head>
-    <body>
-    <h1 id=""article"">Article</h1>
-<p>This is the article</p>
-    </body>
-    </html>
-".SanitizeNewlines(); 
+    cSanitizeNewlines(); 
     
     [Test]
     public async Task TestWithNothing()
@@ -122,7 +112,14 @@ This is the article";
         
         Assert.AreEqual(ExpectedIntroOutput.SanitizeNewlines(), outputFileSystem.Files["gen/intro.html"].SanitizeNewlines());
         Assert.AreEqual(ExpectedChapterOneOutput.SanitizeNewlines(), outputFileSystem.Files["gen/01.html"].SanitizeNewlines());
-        Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["article.html"].SanitizeNewlines());
+
+
+
+
+        Assert.AreEqual(
+        Regex.Replace(ExpectedArticleOutput.SanitizeNewlines(), @"\s+", ""),
+        Regex.Replace(outputFileSystem.Files["article.html"].SanitizeNewlines(), @"\s+", "")
+        );
         Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["second.html"].SanitizeNewlines());
     }
 }

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -33,8 +33,18 @@ This is the intro";
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
 This is the article";
-    private string ExpectedArticleOutput = @"<h1 id=""article"">Article</h1>
-<p>This is the article</p>
+    private string ExpectedArticleOutput = @"
+    <html lang=""en"">
+    <head>
+    <meta charset=""UTF-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+    <title>Article</title>
+    </head>
+    <body>
+    <h1 id=""article"">Article</h1>
+    <p>This is the article</p>
+    </body>
+    </html>
 ".SanitizeNewlines();
     
     [Test]

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -125,8 +125,8 @@ This is the article";
         Assert.AreEqual(ExpectedIntroOutput.SanitizeNewlines(), outputFileSystem.Files["gen/intro.html"].SanitizeNewlines());
         Assert.AreEqual(ExpectedChapterOneOutput.SanitizeNewlines(), outputFileSystem.Files["gen/01.html"].SanitizeNewlines());
         Assert.AreEqual(
-        Regex.Replace(ExpectedArticleOutput.SanitizeNewlines(), @"\s+", ""),
-        Regex.Replace(outputFileSystem.Files["article.html"].SanitizeNewlines(), @"\s+", "")
+        Regex.Replace(ExpectedArticleOutput, @"\s+", ""),
+        Regex.Replace(outputFileSystem.Files["article.html"], @"\s+", "")
         );
         Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["second.html"].SanitizeNewlines());
     }

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -34,7 +34,10 @@ This is the intro";
 <p>This is the intro</p>
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
-This is the article".SanitizeNewlines(); 
+This is the article";
+    private string ExpectedArticleOutput = @"<h1 id=""article"">Article</h1>
+<p>This is the article</p>
+".SanitizeNewlines();
     
     [Test]
     public async Task TestWithNothing()
@@ -111,12 +114,10 @@ This is the article".SanitizeNewlines();
         
         Assert.AreEqual(ExpectedIntroOutput.SanitizeNewlines(), outputFileSystem.Files["gen/intro.html"].SanitizeNewlines());
         Assert.AreEqual(ExpectedChapterOneOutput.SanitizeNewlines(), outputFileSystem.Files["gen/01.html"].SanitizeNewlines());
-
         Assert.AreEqual(
         Regex.Replace(ExpectedArticleOutput.SanitizeNewlines(), @"\s+", ""),
         Regex.Replace(outputFileSystem.Files["article.html"].SanitizeNewlines(), @"\s+", "")
         );
-
         Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["second.html"].SanitizeNewlines());
     }
 }

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -8,6 +8,8 @@ using ScriptureRenderingPipelineWorker.Models;
 using ScriptureRenderingPipelineWorker.Renderers;
 using SRPTests.TestHelpers;
 using System.Text.RegularExpressions;
+using System.Linq;
+
 
 
 namespace SRPTests;
@@ -47,7 +49,7 @@ This is the article";
 <p>This is the article</p>
     </body>
     </html>
-".SanitizeNewlines(); 
+"; 
     
     [Test]
     public async Task TestWithNothing()
@@ -124,10 +126,7 @@ This is the article";
         
         Assert.AreEqual(ExpectedIntroOutput.SanitizeNewlines(), outputFileSystem.Files["gen/intro.html"].SanitizeNewlines());
         Assert.AreEqual(ExpectedChapterOneOutput.SanitizeNewlines(), outputFileSystem.Files["gen/01.html"].SanitizeNewlines());
-        Assert.AreEqual(
-        Regex.Replace(ExpectedArticleOutput, @"\s+", ""),
-        Regex.Replace(outputFileSystem.Files["article.html"], @"\s+", "")
-        );
-        Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["second.html"].SanitizeNewlines());
+
+        Assert.AreEqual(Regex.Replace(ExpectedArticleOutput, @"\s+", String.Empty), Regex.Replace(outputFileSystem.Files["article.html"], @"\s+", String.Empty));
     }
 }

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -41,7 +41,7 @@ This is the article";
     <title>article</title>
     </head>
     <body>
-    <h1 id=""article"">article</h1>
+    <h1 id=""article"">Article</h1>
     <p>This is the article</p>
     </body>
     </html>

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -42,7 +42,7 @@ This is the article";
     </head>
     <body>
     <h1 id=""article"">Article</h1>
-    <p>This is the article</p>
+<p>This is the article</p>
     </body>
     </html>
 ".SanitizeNewlines(); 

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -35,9 +35,19 @@ This is the intro";
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
 This is the article";
-    private string ExpectedArticleOutput = @"<h1 id=""article"">Article</h1>
+    private string ExpectedArticleOutput = @"
+    <html lang=""en"">
+    <head>
+    <meta charset=""UTF-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+    <title>article</title>
+    </head>
+    <body>
+    <h1 id=""article"">Article</h1>
 <p>This is the article</p>
-".SanitizeNewlines();
+    </body>
+    </html>
+".SanitizeNewlines(); 
     
     [Test]
     public async Task TestWithNothing()

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -38,7 +38,7 @@ This is the article";
     <head>
     <meta charset=""UTF-8"">
     <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
-    <title>Article</title>
+    <title>article</title>
     </head>
     <body>
     <h1 id=""article"">article</h1>

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -41,7 +41,7 @@ This is the article";
     <title>Article</title>
     </head>
     <body>
-    <h1 id=""article"">Article</h1>
+    <h1 id=""article"">article</h1>
     <p>This is the article</p>
     </body>
     </html>

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -8,7 +8,6 @@ using ScriptureRenderingPipelineWorker.Models;
 using ScriptureRenderingPipelineWorker.Renderers;
 using SRPTests.TestHelpers;
 using System.Text.RegularExpressions;
-using System.Linq;
 
 
 

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -35,7 +35,7 @@ This is the intro";
 ".SanitizeNewlines();
     private const string ArticleContent = @"# Article
 This is the article";
-    cSanitizeNewlines(); 
+    SanitizeNewlines(); 
     
     [Test]
     public async Task TestWithNothing()
@@ -113,13 +113,11 @@ This is the article";
         Assert.AreEqual(ExpectedIntroOutput.SanitizeNewlines(), outputFileSystem.Files["gen/intro.html"].SanitizeNewlines());
         Assert.AreEqual(ExpectedChapterOneOutput.SanitizeNewlines(), outputFileSystem.Files["gen/01.html"].SanitizeNewlines());
 
-
-
-
         Assert.AreEqual(
         Regex.Replace(ExpectedArticleOutput.SanitizeNewlines(), @"\s+", ""),
         Regex.Replace(outputFileSystem.Files["article.html"].SanitizeNewlines(), @"\s+", "")
         );
+
         Assert.AreEqual(ExpectedArticleOutput.SanitizeNewlines(), outputFileSystem.Files["second.html"].SanitizeNewlines());
     }
 }

--- a/SRPTests/CommentaryRendererTests.cs
+++ b/SRPTests/CommentaryRendererTests.cs
@@ -45,7 +45,7 @@ This is the article";
     <p>This is the article</p>
     </body>
     </html>
-".SanitizeNewlines()
+".SanitizeNewlines(); 
     
     [Test]
     public async Task TestWithNothing()

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -114,7 +114,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				<body>
 				{tmpContent}
 				</body>
-				</html>".Replace("\t", "    ");
+				</html>".Replace("\t", " ");
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -119,7 +119,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 
-				outputTasks.Add(outputWrapper.WriteAllTextAsync($"{title}.html", tmpContent));
+				outputTasks.Add(outputWrapper.WriteAllTextAsync($"{title}.html", htmlMetaWrappedContent));
 			}
 
 			outputTasks.Add(outputWrapper.WriteAllTextAsync("print_all.html",

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -107,15 +107,14 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				var htmlMetaWrappedContent = $@"
 				<html lang=""en"">
 				<head>
-					<meta charset=""UTF-8"">
-					<meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
-					<title>{title}</title>
+				<meta charset=""UTF-8"">
+				<meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+				<title>{title}</title>
 				</head>
 				<body>
-					{tmpContent}
+				{tmpContent}
 				</body>
-				</html>
-			";
+				</html>";
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -114,7 +114,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				<body>
 				{tmpContent}
 				</body>
-				</html>";
+				</html>".Replace("\t", "    ");
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -116,7 +116,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				</body>
 				</html>";
 				// Add articles to print copy
-				printStringBuilder.Append(htmlMetaWrappedContent);
+				printStringBuilder.Append(tmpContent);
 
 				outputTasks.Add(outputWrapper.WriteAllTextAsync($"{title}.html", htmlMetaWrappedContent));
 			}

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -114,7 +114,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				<body>
 				{tmpContent}
 				</body>
-				</html>"
+				</html>";
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -114,7 +114,7 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 				<body>
 				{tmpContent}
 				</body>
-				</html>".Replace("\t", " ");
+				</html>"
 				// Add articles to print copy
 				printStringBuilder.Append(htmlMetaWrappedContent);
 

--- a/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
+++ b/ScriptureRenderingPipelineWorker/Renderers/CommentaryRenderer.cs
@@ -104,8 +104,20 @@ namespace ScriptureRenderingPipelineWorker.Renderers
 			{
 				RewriteLinks(article);
 				var tmpContent = article.ToHtml(pipeline);
+				var htmlMetaWrappedContent = $@"
+				<html lang=""en"">
+				<head>
+					<meta charset=""UTF-8"">
+					<meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+					<title>{title}</title>
+				</head>
+				<body>
+					{tmpContent}
+				</body>
+				</html>
+			";
 				// Add articles to print copy
-				printStringBuilder.Append(tmpContent);
+				printStringBuilder.Append(htmlMetaWrappedContent);
 
 				outputTasks.Add(outputWrapper.WriteAllTextAsync($"{title}.html", tmpContent));
 			}


### PR DESCRIPTION
It's small, but if we want to just kick out to this as an isolated document, you get utf problems without the utf meta tag.  This PR just wraps the minimum of an html document.  Doesn't break anything if you append a whole document as innerHTML as a dom node somewhere though.
https://read.bibletranslationtools.org/u/WycliffeAssociates/en_bc/messiahchrist.html