### PR TITLE
Handle chunk division in bridges

### DIFF
--- a/BTTWriterCatalog/ContentConverters/Scripture.cs
+++ b/BTTWriterCatalog/ContentConverters/Scripture.cs
@@ -72,8 +72,21 @@ public static class Scripture
                         }
                         var maxVerseNumberLength = allVerses.Select(c => c.EndingVerse).Max().ToString().Length;
                         var outputChapter = new ScriptureChapter() { ChapterNumber = chapterNumber.ToString().PadLeft(maxChapterNumberLength, '0'), Reference = string.Empty, Title = string.Empty };
-                        foreach (var chunk in chapterChunks)
+                        for (int i = 0; i < chapterChunks.Count; i++)
                         {
+                            var chunk = chapterChunks[i];
+                            // Look if we need to adjust the chunk to include a verse bridge
+                            var bridge = allVerses.FirstOrDefault(v => v.StartingVerse < v.EndingVerse && chunk.EndingVerse >= v.StartingVerse && chunk.EndingVerse < v.EndingVerse);
+                            if (bridge != null)
+                            {
+                                // Extend chunk to end of bridge
+                                chunk.EndingVerse = bridge.EndingVerse;
+                                // Adjust next chunk to avoid duplication
+                                if (i + 1 < chapterChunks.Count)
+                                {
+                                    chapterChunks[i + 1].StartingVerse = bridge.EndingVerse + 1;
+                                }
+                            }
                             // Create a new USFM document, insert all the verses for this chunk and then convert them to USX
                             var content = new USFMDocument();
                             content.InsertMultiple(allVerses.Where(v => v.StartingVerse >= chunk.StartingVerse && (chunk.EndingVerse == 0 || v.EndingVerse <= chunk.EndingVerse)));

--- a/BTTWriterCatalog/ContentConverters/Scripture.cs
+++ b/BTTWriterCatalog/ContentConverters/Scripture.cs
@@ -102,6 +102,7 @@ public static class Scripture
                                 (chunk.EndingVerse == 0 || v.EndingVerse <= chunk.EndingVerse)).ToArray();
                             if (verseInChunk.Length == 0)
                             {
+                                log.LogInformation("Skipping chunk {Chunk} for {Book} {Chapter} because it contains no verses. StartingVerse: {StartingVerse}, EndingVerse: {EndingVerse}", i, bookAbbreviation, chapterNumber, chunk.StartingVerse, chunk.EndingVerse);
                                 continue;
                             }
                             content.InsertMultiple(verseInChunk);

--- a/BTTWriterCatalog/ContentConverters/Scripture.cs
+++ b/BTTWriterCatalog/ContentConverters/Scripture.cs
@@ -78,7 +78,7 @@ public static class Scripture
                             
                             if (chunk.StartingVerse > chunk.EndingVerse)
                             {
-                                log.LogWarning("Skipping chunk {Chunk} for {Book} {Chapter} because the starting verse is greater than the ending verse, probably due to a verse bridge expansion", i, bookAbbreviation, chapterNumber);
+                                log.LogWarning("Skipping chunk for {Book} {Chapter} because the starting verse is greater than the ending verse, probably due to a verse bridge expansion", bookAbbreviation, chapterNumber);
                                 continue;
                             }
                             
@@ -102,7 +102,7 @@ public static class Scripture
                                 (chunk.EndingVerse == 0 || v.EndingVerse <= chunk.EndingVerse)).ToArray();
                             if (verseInChunk.Length == 0)
                             {
-                                log.LogInformation("Skipping chunk {Chunk} for {Book} {Chapter} because it contains no verses. StartingVerse: {StartingVerse}, EndingVerse: {EndingVerse}", i, bookAbbreviation, chapterNumber, chunk.StartingVerse, chunk.EndingVerse);
+                                log.LogInformation("Skipping chunk for {Book} {Chapter} because it contains no verses. StartingVerse: {StartingVerse}, EndingVerse: {EndingVerse}",  bookAbbreviation, chapterNumber, chunk.StartingVerse, chunk.EndingVerse);
                                 continue;
                             }
                             content.InsertMultiple(verseInChunk);

--- a/SRPTests/BTTWriterCatalogTests/ConverterTests.cs
+++ b/SRPTests/BTTWriterCatalogTests/ConverterTests.cs
@@ -219,6 +219,6 @@ public class ConverterTests
         Assert.AreEqual("5", outputChunks.Chapters[0].Frames[0].LastVerse, "First frame should end at verse 5.");
         Assert.AreEqual("1-6", outputChunks.Chapters[0].Frames[1].Id, "Second id should be 1-6");
         Assert.AreEqual("6", outputChunks.Chapters[0].Frames[1].LastVerse, "Second frame should end at verse 6.");
-        Assert.IsTrue(outputChunks.Chapters[0].Frames[1].Text.Contains("God said, Let there be light: and there was light."), "Second frame should contain bridge text.");
+        Assert.IsFalse(outputChunks.Chapters[0].Frames[1].Text.Contains("God said, Let there be light: and there was light."), "Second frame should not contain bridge text.");
     }
 }

--- a/SRPTests/BTTWriterCatalogTests/ConverterTests.cs
+++ b/SRPTests/BTTWriterCatalogTests/ConverterTests.cs
@@ -116,4 +116,74 @@ public class ConverterTests
         Assert.AreEqual("1", outputChunks.Chapters[0].Frames[0].LastVerse);
         Assert.AreEqual($"<verse number=\"1\" style=\"v\" />{Environment.NewLine}In the beginning God created the heavens and the earth.", outputChunks.Chapters[0].Frames[0].Text);
     }
+
+    [Test]
+    public async Task TestChunkStartsInMiddleOfVerseBridge_AdjustsPreviousChunkAndIncludesBridge()
+    {
+        var basePath = "path";
+        // USFM with a verse bridge: verse 3-5, a verse 2, and a verse 6 outside the bridge
+        var usfmContent = "\\c 1 \\v 2 And darkness was upon the face of the deep. \\v 3-5 And the Lord said, 'Let there be light.' And there was light. And it was good. \\v 6 And the evening and the morning were the first day.";
+        var fileSystem = new FakeZipFileSystem();
+        fileSystem.AddFile("path/gen.usfm", usfmContent);
+        var outputInterface = new FakeOutputInterface();
+        // Chunks: 1-3 and 4-6, as is proper and sequential
+        var chunks = new Dictionary<string, Dictionary<int, List<VerseChunk>>>()
+        {
+            ["GEN"] = new()
+            {
+                [1] = new() { new VerseChunk(1, 3), new VerseChunk(4, 6) }
+            }
+        };
+        var resourceContainer = new ResourceContainer()
+        {
+            projects = new [] { new Project() { identifier = "GEN", path = "gen.usfm" } }
+        };
+
+        await Scripture.ConvertAsync(fileSystem, basePath, outputInterface, resourceContainer, chunks, new FakeLogger());
+        var outputChunks = JsonSerializer.Deserialize<ScriptureResource>(outputInterface.Files["gen/source.json"]);
+        // There should be two frames: one for 1-3 (including the bridge), one for 4-6
+        Assert.AreEqual(2, outputChunks.Chapters[0].Frames.Count, "There should be two frames: one for 1-3, one for 4-6, not duplicated.");
+        Assert.AreEqual("1-1", outputChunks.Chapters[0].Frames[0].Id, "First id should be 1-1, starting at verse 1.");
+        Assert.AreEqual("5", outputChunks.Chapters[0].Frames[0].LastVerse, "First frame should end at verse 5.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[0].Text.Contains("Let there be light."), "First frame should contain the bridge text.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[0].Text.Contains("And it was good."), "First frame should contain the full bridge text.");
+        Assert.AreEqual("1-6", outputChunks.Chapters[0].Frames[1].Id, "Second frame should be just verse 6");
+        Assert.AreEqual("6", outputChunks.Chapters[0].Frames[1].LastVerse, "Second frame should end at verse 6.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[1].Text.Contains("the evening and the morning were the first day"), "Second frame should contain verse 6 text.");
+    }
+
+    [Test]
+    public async Task TestChunkBoundariesAlignedWithVerseBridges()
+    {
+        var basePath = "path";
+        var usfmContent = "\\c 1 \\v 1 In the beginning God created the heavens and the earth. \\v 2 And the earth was without form, and void; \\v 3 And darkness was upon the face of the deep. \\v 4-5 And the Spirit of God moved upon the face of the waters. And God said, Let there be light: and there was light. \\v 6 And God saw the light, that it was good: and God divided the light from the darkness.";
+        var fileSystem = new FakeZipFileSystem();
+        fileSystem.AddFile("path/gen.usfm", usfmContent);
+        var outputInterface = new FakeOutputInterface();
+        var chunks = new Dictionary<string, Dictionary<int, List<VerseChunk>>>()
+        {
+            ["GEN"] = new()
+            {
+                [1] = new() { new VerseChunk(1, 3), new VerseChunk(4, 6) }
+            }
+        };
+        var resourceContainer = new ResourceContainer()
+        {
+            projects = new [] { new Project() { identifier = "GEN", path = "gen.usfm" } }
+        };
+
+        await Scripture.ConvertAsync(fileSystem, basePath, outputInterface, resourceContainer, chunks, new FakeLogger());
+        var outputChunks = JsonSerializer.Deserialize<ScriptureResource>(outputInterface.Files["gen/source.json"]);
+        // There should be two frames: one for 1-3, one for 4-6, perfectly aligned with chunk boundaries
+        Assert.AreEqual(2, outputChunks.Chapters[0].Frames.Count, "There should be two frames: one for 1-3, one for 4-6, aligned with chunk boundaries.");
+        Assert.AreEqual("1-1", outputChunks.Chapters[0].Frames[0].Id, "First id should be 1-1, starting at verse 1.");
+        Assert.AreEqual("3", outputChunks.Chapters[0].Frames[0].LastVerse, "First frame should end at verse 3.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[0].Text.Contains("In the beginning God created the heavens and the earth."), "First frame should contain verse 1 text.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[0].Text.Contains("And darkness was upon the face of the deep."), "First frame should contain verse 3 text.");
+        Assert.AreEqual("1-4", outputChunks.Chapters[0].Frames[1].Id, "Second frame should be 4-6");
+        Assert.AreEqual("6", outputChunks.Chapters[0].Frames[1].LastVerse, "Second frame should end at verse 6.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[1].Text.Contains("And the Spirit of God moved upon the face of the waters."), "Second frame should contain verse 4-5 bridge text.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[1].Text.Contains("God said, Let there be light: and there was light."), "Second frame should contain verse 4-5 bridge text.");
+        Assert.IsTrue(outputChunks.Chapters[0].Frames[1].Text.Contains("God saw the light, that it was good:"), "Second frame should contain verse 6 text.");
+    }
 }


### PR DESCRIPTION
- **If we're going to stop a chunk in a bridge extend it to the end of the bridge**
- **Add failing test for engulfed chunk**
- **When a chunk gets entirely swallowed up by a bridge expansion then don't include it**
- **Fixing up tests a little bit**
