### PR TITLE
Remove language code length limit for Scripture Burrito

### DIFF
--- a/ScriptureRenderingPipelineWorker/MergeHandler.cs
+++ b/ScriptureRenderingPipelineWorker/MergeHandler.cs
@@ -357,7 +357,7 @@ public class MergeTrigger
 			Languages = [
 				new ScriptureBurrito.Models.Language()
 				{
-					Tag = languageCode
+					Tag = languageCode,
 					Name = new Dictionary<string, string>()
 					{
 						["en"] = languageName,

--- a/ScriptureRenderingPipelineWorker/MergeHandler.cs
+++ b/ScriptureRenderingPipelineWorker/MergeHandler.cs
@@ -357,7 +357,7 @@ public class MergeTrigger
 			Languages = [
 				new ScriptureBurrito.Models.Language()
 				{
-					Tag = TruncateString(languageCode, 8), // Max 8 characters as in BCP 47
+					Tag = languageCode
 					Name = new Dictionary<string, string>()
 					{
 						["en"] = languageName,


### PR DESCRIPTION
The 8 character limit of BCP47 is with respect only to the primary language subtag (https://datatracker.ietf.org/doc/html/rfc5646#section-4.4.1), which means that many of our language tags would be improperly truncated to an invalid language code (and only in the burrito, the resource container contains an un-truncated language code). 

This has resulted in a bug from a merged repo with the language code: nya-x-nyanja (which is present in the resource container) where the scripture burrito metadata is now truncating to nya-x-ny.

BCP 47 requires a minimum buffer size of 35 (and recommends 42), however it would be better to validate a language code prior to this line and throw an error rather than force truncation to an even more invalid language code.

If validation is indeed necessary, at least for the scripture burrito section it would be better not to restrict the buffer size, but rather validate against the official Scripture Burrito languageTag regex defined here: https://docs.burrito.bible/en/latest/schema_docs/common.html#common-definitions