### PR TITLE
Update Merge Metadata

### DIFF
--- a/PipelineCommon/Helpers/TranslationDatabaseInterface.cs
+++ b/PipelineCommon/Helpers/TranslationDatabaseInterface.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 
 namespace PipelineCommon.Helpers
 {
-    internal static class TranslationDatabaseInterface
+    public static class TranslationDatabaseInterface
     {
         public static async Task<TranslationDatabaseLanguage> GetLangagueAsync(string path, string languageCode)
         {

--- a/PipelineCommon/Models/TranslationDatabaseLanguage.cs
+++ b/PipelineCommon/Models/TranslationDatabaseLanguage.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace PipelineCommon.Models
 {
-    internal class TranslationDatabaseLanguage
+    public class TranslationDatabaseLanguage
     {
        [JsonPropertyName("cc")]
         public List<string> Countries { get; set; }

--- a/ScriptureRenderingPipelineWorker/MergeHandler.cs
+++ b/ScriptureRenderingPipelineWorker/MergeHandler.cs
@@ -334,6 +334,9 @@ public class MergeTrigger
 	}
 	private static BurritoSerializationRoot CreateBurrito(string projectName, string projectAbbreviation, string languageCode, string languageName, string englishLanguageName, string languageTextDirection, List<ContentForBurrito> content, string username)
 	{
+		var applicationVersion =
+			typeof(MergeTrigger).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+				?.InformationalVersion ?? "unknown";
 		return new BurritoSerializationRoot()
 		{
 			Meta = new Meta()
@@ -343,7 +346,7 @@ public class MergeTrigger
 				Generator = new ScriptureBurrito.Models.Generator() 
 				{
 					SoftwareName = "Repo consolidator",
-					SoftwareVersion = typeof(MergeTrigger).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
+					SoftwareVersion = applicationVersion,
 					UserName = username
 				},
 				DefaultLocale = "en",

--- a/ScriptureRenderingPipelineWorker/MergeHandler.cs
+++ b/ScriptureRenderingPipelineWorker/MergeHandler.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using System.Security.Cryptography;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
@@ -196,8 +197,9 @@ public class MergeTrigger
 
 		if (_burritoEnabled)
 		{
-			// Create a scripture burrito for this merged repo
-			var burrito = CreateBurrito("Bible", "bible", languageCode, languageName, languageDirection,
+			var langInfo = await TranslationDatabaseInterface.GetLangagueAsync("https://langnames.bibleineverylanguage.org/langnames.json", languageCode);
+			var englishLanguageName = langInfo?.AnglicizedName ?? languageName;
+			var burrito = CreateBurrito("Bible", "bible", languageCode, languageName, englishLanguageName, languageDirection,
 				contentForBurrito.OrderBy(i => Utils.GetBookNumber(i.BookCode)).ToList(), message.RequestingUserName);
         
 			output.Add("metadata.json", BurritoSerializer.Serialize(burrito));
@@ -330,7 +332,7 @@ public class MergeTrigger
 			return input;
 		return input.Substring(0, maxLength);
 	}
-	private static BurritoSerializationRoot CreateBurrito(string projectName, string projectAbbreviation, string languageCode, string languageName, string languageTextDirection, List<ContentForBurrito> content, string username)
+	private static BurritoSerializationRoot CreateBurrito(string projectName, string projectAbbreviation, string languageCode, string languageName, string englishLanguageName, string languageTextDirection, List<ContentForBurrito> content, string username)
 	{
 		return new BurritoSerializationRoot()
 		{
@@ -341,7 +343,7 @@ public class MergeTrigger
 				Generator = new ScriptureBurrito.Models.Generator() 
 				{
 					SoftwareName = "Repo consolidator",
-					SoftwareVersion = "1.0.0",
+					SoftwareVersion = typeof(MergeTrigger).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unknown",
 					UserName = username
 				},
 				DefaultLocale = "en",
@@ -390,7 +392,7 @@ public class MergeTrigger
 					Tag = languageCode,
 					Name = new Dictionary<string, string>()
 					{
-						["en"] = languageName,
+						["en"] = englishLanguageName,
 						[languageCode] = languageName
 					},
 					ScriptDirection = languageTextDirection

--- a/ScriptureRenderingPipelineWorker/ScriptureRenderingPipelineWorker.csproj
+++ b/ScriptureRenderingPipelineWorker/ScriptureRenderingPipelineWorker.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <Version>1.0.0</Version>
         <TargetFramework>net8.0</TargetFramework>
         <AzureFunctionsVersion>v4</AzureFunctionsVersion>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
This pull request updates the pipeline to improve how language metadata and versioning are handled when generating scripture burrito metadata. It makes the translation database interface and language model publicly accessible, retrieves the anglicized (English) language name from an external service for metadata, and ensures the generated metadata reflects the actual application version.

**Metadata and Language Handling Improvements:**

* The `TranslationDatabaseInterface` and `TranslationDatabaseLanguage` classes are now public, allowing them to be accessed from other projects. [[1]](diffhunk://#diff-46c9b030bd6f619175cbf497d867fc86998fc73e376501ff85056ffbc86c4ff5L9-R9) [[2]](diffhunk://#diff-b46e29b356c070999bc02dea3f4aab8f329c5701acc9ebb14c0680dbe1a4204cL6-R6)
* The merge handler now fetches the anglicized (English) language name from an external language database and uses it in the burrito metadata, improving the accuracy of language information in the generated files. [[1]](diffhunk://#diff-c8db7bd419adadd646fc267fc40ad68badda2d63cf30221f05d3602aa988f50cL199-R202) [[2]](diffhunk://#diff-c8db7bd419adadd646fc267fc40ad68badda2d63cf30221f05d3602aa988f50cL393-R398)

**Versioning Enhancements:**

* The burrito metadata now includes the actual application version (from assembly attributes) instead of a hardcoded value, ensuring better traceability of generated artifacts. [[1]](diffhunk://#diff-c8db7bd419adadd646fc267fc40ad68badda2d63cf30221f05d3602aa988f50cL333-R339) [[2]](diffhunk://#diff-c8db7bd419adadd646fc267fc40ad68badda2d63cf30221f05d3602aa988f50cL344-R349) [[3]](diffhunk://#diff-a3162e72063de2cd0b929216422ac2c72a3e03bfe7bdee2f51e91e9958823762R3)

**Other Minor Changes:**

* Added a missing `using System.Reflection;` directive to support reading assembly attributes.- **Added english name and generator version**
- **Moved things around a little bit**
