### PR TITLE
Check bicep file on PR

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -34,3 +34,12 @@ jobs:
       run: dotnet build "${{ env.RENDERING_WORKER_WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Run Tests
       run: dotnet test
+
+  validate-bicep:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Bicep CLI
+      run: az bicep install
+    - name: Build and lint Bicep template
+      run: az bicep build --file infra/main.bicep


### PR DESCRIPTION
This pull request adds a new workflow job to the GitHub Actions configuration to validate Bicep infrastructure templates. The main change is the introduction of automated Bicep linting and building as part of the CI process.

**CI/CD pipeline improvements:**

* Added a new `validate-bicep` job to `.github/workflows/pullRequest.yml` that checks out the code, installs the Bicep CLI, and runs build/lint on the `infra/main.bicep` template.