### PR TITLE
Added missing items to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ The following configuration values are used across multiple components:
 | `ConnectionStrings:Database` | SQL Database connection string | Yes |
 | `ConnectionStrings:ServiceBus` | Service Bus connection string | Yes |
 | `ConnectionStrings:Dataverse` | PORT system connection string | Yes |
+| `Gitea:Url` | Base URL of the Gitea instance | Yes |
+| `Gitea:User` | Gitea API user | Yes |
+| `Gitea:Password` | Gitea API password/token | Yes |
 | `MaxServiceBusConnections` | Max concurrent connections (default: 1) | No |
 
 ### Setting Up Configuration
@@ -293,6 +296,9 @@ docker run -d \
   -e ConnectionStrings__Database="YOUR_SQL_CONNECTION_STRING" \
   -e ConnectionStrings__ServiceBus="YOUR_SERVICE_BUS_CONNECTION_STRING" \
   -e ConnectionStrings__Dataverse="YOUR_PORT_CONNECTION_STRING" \
+  -e Gitea__Url="YOUR_GITEA_URL" \
+  -e Gitea__User="YOUR_GITEA_USER" \
+  -e Gitea__Password="YOUR_GITEA_PASSWORD" \
   verse-reporting-processor
 
 # Or use docker-compose

--- a/VerseReportingProcessor/docker-compose.yml
+++ b/VerseReportingProcessor/docker-compose.yml
@@ -7,6 +7,9 @@
       - ConnectionStrings__Database
       - ConnectionStrings__BlobStorage
       - ConnectionStrings__Dataverse
+      - Gitea__Url
+      - Gitea__User
+      - Gitea__Password
       - MaxServiceBusConnections
       - EnableDatabasePush
       - EnablePortPush


### PR DESCRIPTION
This pull request updates the configuration documentation and deployment setup to include new environment variables required for integrating with a Gitea instance. The changes ensure that the application can be properly configured to connect to Gitea by specifying its URL, user, and password/token.

Configuration documentation and deployment updates:

* Added `Gitea:Url`, `Gitea:User`, and `Gitea:Password` configuration values to the shared configuration table in `README.md`, documenting their purpose and required status.
* Updated the `docker run` command example in `README.md` to include the new Gitea-related environment variables for proper container configuration.
* Added `Gitea__Url`, `Gitea__User`, and `Gitea__Password` to the environment variable list in `VerseReportingProcessor/docker-compose.yml` to support configuration via Docker Compose.