### PR TITLE
Handle repos that are too big

### DIFF
--- a/PipelineCommon/Helpers/Utils.cs
+++ b/PipelineCommon/Helpers/Utils.cs
@@ -43,6 +43,19 @@ namespace PipelineCommon.Helpers
         }
         
         /// <summary>
+        /// Determines whether a repository is too large to download and process.
+        /// Gitea reports repository size in kibibytes (see the webhook payload's repository.size),
+        /// while the limit is configured in megabytes for readability.
+        /// </summary>
+        /// <param name="repoSizeInKB">Repository size in kibibytes, as reported by Gitea.</param>
+        /// <param name="maxRepoSizeInMB">Configured maximum size in megabytes. A value of 0 (or less) disables the check.</param>
+        /// <returns>True if the repository exceeds the configured limit and should be skipped.</returns>
+        public static bool IsRepoTooLarge(int repoSizeInKB, int maxRepoSizeInMB)
+        {
+            return maxRepoSizeInMB > 0 && repoSizeInKB > maxRepoSizeInMB * 1024;
+        }
+
+        /// <summary>
         /// Generates a download link for a given repository.
         /// </summary>
         /// <param name="htmlUrl">The HTML URL of the repository.</param>

--- a/PipelineCommon/Models/BusMessages/WACSMessage.cs
+++ b/PipelineCommon/Models/BusMessages/WACSMessage.cs
@@ -12,4 +12,8 @@ public class WACSMessage
     public string Action { get; set; }
     public string DefaultBranch { get; set; }
     public string[] Topics { get; set; }
+    /// <summary>
+    /// Repository size in kibibytes, as reported by Gitea in the webhook payload.
+    /// </summary>
+    public int RepoSizeInKB { get; set; }
 }

--- a/SRPTests/UtilsTests.cs
+++ b/SRPTests/UtilsTests.cs
@@ -32,6 +32,20 @@ public class UtilsTests
       Directory.Delete(tmp);
    }
 
+   /// <summary>
+   /// Verify the repository size limit check. Gitea reports size in KiB; the limit is configured in MB.
+   /// </summary>
+   [TestCase(0, 0, ExpectedResult = false, TestName = "Disabled when limit is zero")]
+   [TestCase(10_000_000, 0, ExpectedResult = false, TestName = "Disabled ignores huge repos")]
+   [TestCase(50 * 1024, 100, ExpectedResult = false, TestName = "Under the limit")]
+   [TestCase(100 * 1024, 100, ExpectedResult = false, TestName = "Exactly at the limit is allowed")]
+   [TestCase(100 * 1024 + 1, 100, ExpectedResult = true, TestName = "One KiB over the limit")]
+   [TestCase(500 * 1024, 100, ExpectedResult = true, TestName = "Well over the limit")]
+   public bool TestIsRepoTooLarge(int repoSizeInKB, int maxRepoSizeInMB)
+   {
+      return Utils.IsRepoTooLarge(repoSizeInKB, maxRepoSizeInMB);
+   }
+
    [Test]
    public void TestGetRepoType()
    {

--- a/ScriptureRenderingPipeline/Webhook.cs
+++ b/ScriptureRenderingPipeline/Webhook.cs
@@ -93,7 +93,8 @@ namespace ScriptureRenderingPipeline
 				RepoId = webhookEvent.repository.Id,
 				Action = webhookEvent.action,
 				DefaultBranch = webhookEvent.repository.default_branch,
-				Topics = webhookEvent.repository.Topics
+				Topics = webhookEvent.repository.Topics,
+				RepoSizeInKB = webhookEvent.repository.Size
 			};
 			if (webhookEvent.commits != null && webhookEvent.commits.Length > 0)
 			{

--- a/ScriptureRenderingPipelineWorker/ProgressReporting.cs
+++ b/ScriptureRenderingPipelineWorker/ProgressReporting.cs
@@ -18,12 +18,14 @@ public class ProgressReporting
     private readonly ILogger<ProgressReporting> _log;
     private readonly ServiceBusClient _serviceBusClient;
     private readonly HttpClient _wacsHttpClient;
+    private readonly int _maxRepoSizeInMB;
     public ProgressReporting(ILogger<ProgressReporting> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory,
     IHttpClientFactory httpClientFactory, IConfiguration configuration)
     {
         _log = logger;
         _serviceBusClient = serviceBusClientFactory.CreateClient("ServiceBusClient");
         _wacsHttpClient = httpClientFactory.CreateClient("WACS");
+        _maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
     }
     [Function("ProgressReporting")]
     [ServiceBusOutput("VerseCountingResult", Connection = "ServiceBusConnectionString")]
@@ -47,6 +49,18 @@ public class ProgressReporting
     private async Task<VerseCountingResult> CountVersesAsync(WACSMessage message)
     {
         _log.LogInformation("Counting Verses for {Username}/{Repo}", message.User, message.Repo);
+
+        if (Utils.IsRepoTooLarge(message.RepoSizeInKB, _maxRepoSizeInMB))
+        {
+            _log.LogWarning("Skipping {Username}/{Repo}: repository size {Size}KB exceeds the limit of {Limit}MB",
+                message.User, message.Repo, message.RepoSizeInKB, _maxRepoSizeInMB);
+            return new VerseCountingResult(message)
+            {
+                Success = false,
+                Message = $"Repository size {message.RepoSizeInKB}KB exceeds the limit of {_maxRepoSizeInMB}MB, skipping"
+            };
+        }
+
         var fileResult = await _wacsHttpClient.GetAsync(Utils.GenerateDownloadLink(message.RepoHtmlUrl, message.User, message.Repo, message.DefaultBranch));
         
 	    _log.LogDebug("Got status code: {StatusCode}", fileResult.StatusCode);

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -23,6 +23,7 @@ public class RenderingTrigger
 	private readonly string _pipelineBaseUrl;
 	private readonly string _resourcesUser;
 	private readonly HttpClient _wacsHttpClient;
+	private readonly int _maxRepoSizeInMB;
 
 	public RenderingTrigger(ILogger<RenderingTrigger> logger,
 		IAzureClientFactory<ServiceBusClient> serviceBusClientFactory,
@@ -37,6 +38,7 @@ public class RenderingTrigger
 		_pipelineBaseUrl = configuration.GetValue<string>("ScriptureRenderingPipelineBaseUrl");
 		_resourcesUser = configuration.GetValue<string>("ScriptureRenderingPipelineResourcesUser");
 		_wacsHttpClient = httpClientFactory.CreateClient("WACS");
+		_maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
 	}
 	
     [Function("RenderingTrigger")]
@@ -100,8 +102,19 @@ public class RenderingTrigger
     private async Task<RenderingResultMessage> RenderRepoAsync(WACSMessage message)
     {
 	    var timeStarted = DateTime.Now;
-	    
+
         _log.LogInformation("Rendering {Username}/{Repo}", message.User, message.Repo);
+
+	    if (Utils.IsRepoTooLarge(message.RepoSizeInKB, _maxRepoSizeInMB))
+	    {
+		    _log.LogWarning("Skipping {Username}/{Repo}: repository size {Size}KB exceeds the limit of {Limit}MB",
+			    message.User, message.Repo, message.RepoSizeInKB, _maxRepoSizeInMB);
+		    return new RenderingResultMessage(message)
+		    {
+			    Successful = false,
+			    Message = $"Repository size {message.RepoSizeInKB}KB exceeds the limit of {_maxRepoSizeInMB}MB, skipping",
+		    };
+	    }
 
 	    var outputDir = new DirectAzureUpload($"/u/{message.User}/{message.Repo}", _outputContainerClient);
 

--- a/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using PipelineCommon.Helpers;
 using PipelineCommon.Models.BusMessages;
@@ -16,18 +17,20 @@ public class RepoAnalysisTrigger
 {
 	private readonly ILogger<RepoAnalysisTrigger> log;
 	private readonly ServiceBusClient client;
+	private readonly int _maxRepoSizeInMB;
 
-	public RepoAnalysisTrigger(ILogger<RepoAnalysisTrigger> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory)
+	public RepoAnalysisTrigger(ILogger<RepoAnalysisTrigger> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory, IConfiguration configuration)
 	{
 		log = logger;
 		client = serviceBusClientFactory.CreateClient("ServiceBusClient");
+		_maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
 	}
 
 	[Function("RepoAnalysisTrigger")]
 	public async Task RunAsync([ServiceBusTrigger("WACSEvent", "RepoAnalysis", IsSessionsEnabled = false, Connection = "ServiceBusConnectionString")] string rawMessage)
 	{
 		var message = JsonSerializer.Deserialize(rawMessage, WorkerJsonContext.Default.WACSMessage);
-		var analysisResult = await AnalyzeRepoAsync(message, log);
+		var analysisResult = await AnalyzeRepoAsync(message, log, _maxRepoSizeInMB);
 		var output = new ServiceBusMessage(JsonSerializer.Serialize(analysisResult, WorkerJsonContext.Default.RepoAnalysisResult))
 		{
 			ApplicationProperties =
@@ -42,11 +45,20 @@ public class RepoAnalysisTrigger
 		await sender.SendMessageAsync(output);
 	}
 
-	private static async Task<RepoAnalysisResult> AnalyzeRepoAsync(WACSMessage message, ILogger log)
+	private static async Task<RepoAnalysisResult> AnalyzeRepoAsync(WACSMessage message, ILogger log, int maxRepoSizeInMB)
 	{
 		log.LogInformation("Analyzing repository {Username}/{Repo}", message.User, message.Repo);
 
 		var result = new RepoAnalysisResult(message);
+
+		if (Utils.IsRepoTooLarge(message.RepoSizeInKB, maxRepoSizeInMB))
+		{
+			log.LogWarning("Skipping {Username}/{Repo}: repository size {Size}KB exceeds the limit of {Limit}MB",
+				message.User, message.Repo, message.RepoSizeInKB, maxRepoSizeInMB);
+			result.Success = false;
+			result.Message = $"Repository size {message.RepoSizeInKB}KB exceeds the limit of {maxRepoSizeInMB}MB, skipping";
+			return result;
+		}
 
 		// Download the repository
 		var fileResult = await Utils.httpClient.GetAsync(Utils.GenerateDownloadLink(message.RepoHtmlUrl, message.User, message.Repo, message.DefaultBranch));


### PR DESCRIPTION
This pull request introduces a repository size limit check throughout the pipeline to prevent processing repositories that are too large, as reported by Gitea. The size check is configurable via the `MaxRepoSizeInMB` setting and is enforced in all major worker functions. The changes also ensure that repository size information is passed along with messages and is properly tested.

**Repository size limit enforcement:**

* Added a utility method `IsRepoTooLarge` in `Utils.cs` to determine if a repository exceeds the configured size limit (in MB), using the size reported by Gitea (in KiB).
* Updated `ProgressReporting`, `RenderingTrigger`, and `RepoAnalysisTrigger` worker classes to read the `MaxRepoSizeInMB` configuration and skip processing if the repository is too large, logging a warning and returning a failure result message. [[1]](diffhunk://#diff-3fdd794db2cef256fc664f3bb7256e28ad178c34d0b5244c2f289c9ed94e3964R21-R28) [[2]](diffhunk://#diff-3fdd794db2cef256fc664f3bb7256e28ad178c34d0b5244c2f289c9ed94e3964R52-R63) [[3]](diffhunk://#diff-2ff179eb7c262acccf1e4369a045d7a1555e4552281f238a271f26c3f88bcc07R26) [[4]](diffhunk://#diff-2ff179eb7c262acccf1e4369a045d7a1555e4552281f238a271f26c3f88bcc07R41) [[5]](diffhunk://#diff-2ff179eb7c262acccf1e4369a045d7a1555e4552281f238a271f26c3f88bcc07R108-R118) [[6]](diffhunk://#diff-49164dadaeb5384bffb9fcb6521dfc3c9f080486f3a7d0e83580a44914f44944R20-R33) [[7]](diffhunk://#diff-49164dadaeb5384bffb9fcb6521dfc3c9f080486f3a7d0e83580a44914f44944L45-R62)

**Message and data model updates:**

* Added a `RepoSizeInKB` property to the `WACSMessage` model to carry the repository size through the pipeline, and populated this field in the webhook handler. [[1]](diffhunk://#diff-fb8732c6e0a49ff9d4872fc3fb5eb4264cc79776d9dd3c0adfb9b8196dd231a4R15-R18) [[2]](diffhunk://#diff-2d52460d3697317bf794d0728522210234e892ce62334c6a4c7543ffcbacc421L96-R97)

**Testing:**

* Added unit tests for the new size limit logic to ensure correct behavior for various edge cases and configurations.

**Dependency injection and configuration:**

* Updated constructors in affected worker classes to accept and store the `MaxRepoSizeInMB` configuration value. [[1]](diffhunk://#diff-3fdd794db2cef256fc664f3bb7256e28ad178c34d0b5244c2f289c9ed94e3964R21-R28) [[2]](diffhunk://#diff-2ff179eb7c262acccf1e4369a045d7a1555e4552281f238a271f26c3f88bcc07R41) [[3]](diffhunk://#diff-49164dadaeb5384bffb9fcb6521dfc3c9f080486f3a7d0e83580a44914f44944R20-R33)

**Minor dependency update:**

* Added a missing `using Microsoft.Extensions.Configuration;` directive in `RepoAnalysisTrigger.cs` to support configuration injection.