### PR TITLE
Always log into WACS when getting data

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
     - name: Restore Rendering

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
     - name: Restore Rendering

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -8,32 +8,21 @@ on: pull_request
 env:
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 10.x
-  RENDERING_WORKING_DIRECTORY: ScriptureRenderingPipeline
-  RENDERING_WORKER_WORKING_DIRECTORY: ScriptureRenderingPipelineWorker
-  CATALOG_WORKING_DIRECTORY: BTTWriterCatalog
 jobs:
   build-and-test:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
-    - name: Restore Rendering
-      run: dotnet restore "${{ env.RENDERING_WORKING_DIRECTORY }}"
-    - name: Restore Catalog
-      run: dotnet restore "${{ env.CATALOG_WORKING_DIRECTORY }}"
-    - name: Restore Rendering Worker
-      run: dotnet restore "${{ env.RENDERING_WORKER_WORKING_DIRECTORY }}"
-    - name: Build Rendering
-      run: dotnet build "${{ env.RENDERING_WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
-    - name: Build Catalog
-      run: dotnet build "${{ env.CATALOG_WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
-    - name: Build Rendering Worker
-      run: dotnet build "${{ env.RENDERING_WORKER_WORKING_DIRECTORY }}" --configuration ${{ env.CONFIGURATION }} --no-restore
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Run Tests
-      run: dotnet test
+      run: dotnet test --configuration ${{ env.CONFIGURATION }} --no-build
 
   validate-bicep:
     runs-on: ubuntu-latest

--- a/PipelineCommon/Helpers/GiteaClient.cs
+++ b/PipelineCommon/Helpers/GiteaClient.cs
@@ -123,7 +123,7 @@ public class GiteaClient: IDisposable
         // We don't want to say a repo isn't there if we got a 500 or something like that
         if (response.StatusCode != HttpStatusCode.NotFound && response.StatusCode != HttpStatusCode.OK)
         {
-            throw new HttpRequestException($"Got an unexpected response from WACS expected 200 or 404 but got {response.StatusCode}");
+            throw new HttpRequestException($"Got an unexpected response from Gitea for {user}/{repo} on branch {branch} expected 200 or 404 but got {response.StatusCode}");
         }
         return response.StatusCode == HttpStatusCode.OK;
     }
@@ -139,7 +139,7 @@ public class GiteaClient: IDisposable
 
         if (!response.IsSuccessStatusCode)
         {
-            throw new HttpRequestException($"Got an unexpected response from Gitea expected 200 or 404 but got {response.StatusCode}");
+            throw new HttpRequestException($"Got an unexpected response from Gitea for {user}/{repo} on branch {branch} expected 200 or 404 but got {response.StatusCode}");
         }
 
         var memoryStream = new MemoryStream();

--- a/PipelineCommon/Helpers/GiteaClient.cs
+++ b/PipelineCommon/Helpers/GiteaClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,6 +21,7 @@ public class GiteaClient: IDisposable
         // Add basic auth
         var byteArray = System.Text.Encoding.UTF8.GetBytes($"{user}:{password}");
         _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "ScriptureRenderingPipeline");
     }
 
     public async Task<Repository?> GetRepository(string user, string repo)
@@ -124,6 +126,27 @@ public class GiteaClient: IDisposable
             throw new HttpRequestException($"Got an unexpected response from WACS expected 200 or 404 but got {response.StatusCode}");
         }
         return response.StatusCode == HttpStatusCode.OK;
+    }
+    public async Task<ZipFileSystem?> GetZipArchive(string user, string repo, string branch)
+    {
+        // We're only waiting for the response headers, otherwise this will wait for the whole body to be in memory
+        // we're going to be copying the stream to be able to dispose the http request to this makes it so we don't have two copies
+        using var response = await _httpClient.GetAsync($"repos/{user}/{repo}/archive/{branch}.zip", HttpCompletionOption.ResponseHeadersRead);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"Got an unexpected response from Gitea expected 200 or 404 but got {response.StatusCode}");
+        }
+
+        var memoryStream = new MemoryStream();
+        var httpStream = await response.Content.ReadAsStreamAsync();
+        await httpStream.CopyToAsync(memoryStream);
+        memoryStream.Position = 0;
+        return new ZipFileSystem(memoryStream);
     }
 
     public void Dispose()

--- a/README.md
+++ b/README.md
@@ -216,6 +216,53 @@ The following configuration values are used across multiple components:
 |------------------|-------------|----------|
 | `ScripturePipelineStorageConnectionString` | Storage connection string for rendered output | Yes |
 | `WebhookStorageConnectionString` | Azure Table Storage connection string for registered outgoing webhooks | Yes |
+| `Gitea:<host>:BaseUrl` | Base URL of the Gitea instance served at `<host>` | Yes |
+| `Gitea:<host>:User` | Gitea API user for that instance | Yes |
+| `Gitea:<host>:Password` | Gitea API password/token for that instance | Yes |
+| `GiteaBaseAddress` | Base URL of the Gitea instance used as the merge destination | Yes, for merging |
+
+###### Gitea credentials are keyed by host
+
+The worker reads repository metadata and downloads repository archives through an
+authenticated Gitea client. Credentials live under a `Gitea` section keyed by hostname, and
+the client is resolved per message from the host of the repository's `html_url`:
+
+```json
+{
+  "Gitea": {
+    "content.example.org": {
+      "BaseUrl": "https://content.example.org",
+      "User": "YOUR_GITEA_USER",
+      "Password": "YOUR_GITEA_PASSWORD"
+    }
+  }
+}
+```
+
+Two things to watch out for:
+
+- **The host key must match exactly, in lowercase.** The lookup key comes from
+  `new Uri(message.RepoHtmlUrl).Host`, which .NET normalizes to lowercase, and the
+  configuration dictionary is compared case-sensitively. `Gitea:Content.Example.Org` will not
+  match a repository at `https://content.example.org`.
+- **Every Gitea instance the worker sees needs its own entry**, including the host in
+  `GiteaBaseAddress` used for merges. A message from a host with no matching entry fails and
+  is retried, rather than falling back to an anonymous download.
+
+As flat settings — Azure Functions app settings, or the `Values` block of
+`local.settings.json` — the section separator becomes a double underscore:
+
+    Gitea__content.example.org__BaseUrl
+    Gitea__content.example.org__User
+    Gitea__content.example.org__Password
+
+Note that these names contain dots, so they cannot be assigned as shell variables in bash
+(`Gitea__content.example.org__BaseUrl=...` is not a valid assignment). Set them in
+`local.settings.json`, in user secrets, or prefixed with `env` for a one-off run:
+
+```bash
+env 'Gitea__content.example.org__BaseUrl=https://content.example.org' func start
+```
 
 ##### BTTWriterCatalog
 
@@ -241,6 +288,9 @@ The following configuration values are used across multiple components:
 | `Gitea:Password` | Gitea API password/token | Yes |
 | `MaxServiceBusConnections` | Max concurrent connections (default: 1) | No |
 
+VerseReportingProcessor talks to a single Gitea instance, so its `Gitea` section is flat —
+this is a different shape from the host-keyed `Gitea` section the worker uses.
+
 ### Setting Up Configuration
 
 Configuration can be provided through:
@@ -259,7 +309,10 @@ Example local.settings.json for Azure Functions:
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "ServiceBusConnectionString": "YOUR_SERVICE_BUS_CONNECTION_STRING",
     "BlobStorageConnectionString": "YOUR_BLOB_STORAGE_CONNECTION_STRING",
-    "AllowedDomain": "example.org"
+    "AllowedDomain": "example.org",
+    "Gitea__content.example.org__BaseUrl": "https://content.example.org",
+    "Gitea__content.example.org__User": "YOUR_GITEA_USER",
+    "Gitea__content.example.org__Password": "YOUR_GITEA_PASSWORD"
   },
   "ConnectionStrings": {
     "Database": "YOUR_SQL_CONNECTION_STRING",

--- a/ScriptureRenderingPipelineWorker/GiteaClientFactory.cs
+++ b/ScriptureRenderingPipelineWorker/GiteaClientFactory.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Configuration;
+using PipelineCommon.Helpers;
+
+namespace ScriptureRenderingPipelineWorker;
+
+public class GiteaClientFactory
+{
+    private Dictionary<string, GiteaConfiguration> _configurations;
+    private Dictionary<string, GiteaClient> _clients = new();
+    private SemaphoreSlim _semaphore = new(1, 1);
+    public GiteaClientFactory(IConfiguration configuration)
+    {
+        _configurations = configuration.GetSection("Gitea").Get<Dictionary<string, GiteaConfiguration>>() ?? throw new InvalidOperationException("Missing Gitea configuration");
+    }
+
+    public GiteaClient CreateClient(string config)
+    {
+        _semaphore.Wait();
+        try
+        {
+            
+            if (_clients.TryGetValue(config, out var cachedClient))
+            {
+                return cachedClient;
+            }
+
+            if (!_configurations.TryGetValue(config, out var giteaConfig))
+            {
+                throw new InvalidOperationException($"Missing Gitea configuration for {config}");
+            }
+
+            var client = new GiteaClient(giteaConfig.BaseUrl, giteaConfig.User, giteaConfig.Password);
+            _clients[config] = client;
+            return client;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+}
+
+internal class GiteaConfiguration
+{
+    public string BaseUrl { get; set; }
+    public string User { get; set; }
+    public string Password { get; set; }
+}

--- a/ScriptureRenderingPipelineWorker/GiteaClientFactory.cs
+++ b/ScriptureRenderingPipelineWorker/GiteaClientFactory.cs
@@ -15,6 +15,7 @@ public class GiteaClientFactory
 
     public GiteaClient CreateClient(string config)
     {
+        config = config.ToLower();
         _semaphore.Wait();
         try
         {

--- a/ScriptureRenderingPipelineWorker/MergeHandler.cs
+++ b/ScriptureRenderingPipelineWorker/MergeHandler.cs
@@ -31,15 +31,15 @@ public class MergeTrigger
 	private readonly string _destinationUser;
 	private readonly string _giteaBaseAddress;
 	private readonly bool _burritoEnabled;
-	public MergeTrigger(ILogger<ProgressReporting> logger,  IConfiguration config)
+	private readonly GiteaClientFactory _giteaClientFactory;
+	public MergeTrigger(ILogger<ProgressReporting> logger,  IConfiguration config, GiteaClientFactory giteaClientFactory)
 	{
 		_log = logger;
 		_giteaBaseAddress = config["GiteaBaseAddress"];
-		var user = config["GiteaUser"];
-		var password = config["GiteaPassword"];
 		_destinationUser = config["MergeDestinationUser"];
-		_giteaClient = new GiteaClient(_giteaBaseAddress, user, password);
+		_giteaClient = giteaClientFactory.CreateClient(new Uri(_giteaBaseAddress).Host);
 		_burritoEnabled = config.GetValue<bool>("ScriptureBurritoMergeEnabled");
+		_giteaClientFactory = giteaClientFactory;
 	}
     
 
@@ -80,8 +80,14 @@ public class MergeTrigger
 
 		foreach (var repo in message.ReposToMerge)
 		{
-			var info = await Utils.GetGiteaRepoInformation(repo.HtmlUrl, repo.User, repo.Repo);
-			var projectZip = await GetProjectAsync(repo.HtmlUrl, repo.User, repo.Repo, info.default_branch, _log);
+			var giteaClient = _giteaClientFactory.CreateClient(new Uri(repo.HtmlUrl).Host); // this is ok in a loop since it gets the cached client if it exists still
+			var info = await giteaClient.GetRepository(repo.User, repo.Repo);
+			if (info == null)
+			{
+				_log.LogError("Unable to load repo {User}/{Repo} as it is missing", repo.User, repo.Repo);
+				continue;
+			}
+			var projectZip = await giteaClient.GetZipArchive(repo.User, repo.Repo, info.default_branch);
 			if (projectZip == null)
 			{
 				_log.LogError("Unable to load repo {User}/{Repo}", repo.User, repo.Repo);
@@ -309,29 +315,6 @@ public class MergeTrigger
 		await _giteaClient.UploadMultipleFiles(user, repoName, content, branch);
 	}
 
-	private static async Task<ZipFileSystem?> GetProjectAsync(string repoHtmlUrl, string user, string repo, string defaultBranch, ILogger log)
-	{
-		var result = await Utils.httpClient.GetAsync(Utils.GenerateDownloadLink(repoHtmlUrl, user, repo, defaultBranch));
-		if (result.StatusCode == HttpStatusCode.NotFound)
-		{
-			log.LogWarning("Repository at {RepositoryUrl} is empty", repoHtmlUrl);
-			return null;
-		}
-
-		if (!result.IsSuccessStatusCode)
-		{
-			log.LogError("Error downloading {RepositoryUrl} status code: {StatusCode}", repoHtmlUrl, result.StatusCode);
-		}
-		var zipStream = await result.Content.ReadAsStreamAsync();
-		return new ZipFileSystem(zipStream);
-	}
-
-	static string TruncateString(string input, int maxLength)
-	{
-		if (string.IsNullOrEmpty(input) || input.Length <= maxLength)
-			return input;
-		return input.Substring(0, maxLength);
-	}
 	private static BurritoSerializationRoot CreateBurrito(string projectName, string projectAbbreviation, string languageCode, string languageName, string englishLanguageName, string languageTextDirection, List<ContentForBurrito> content, string username)
 	{
 		var applicationVersion =

--- a/ScriptureRenderingPipelineWorker/Program.cs
+++ b/ScriptureRenderingPipelineWorker/Program.cs
@@ -19,16 +19,13 @@ var host = new HostBuilder()
             clientBuilder.AddBlobServiceClient(context.Configuration.GetValue<string>("ScripturePipelineStorageConnectionString")).WithName("BlobServiceClient");
             clientBuilder.AddTableServiceClient(context.Configuration.GetValue<string>("WebhookStorageConnectionString")).WithName("WebhookTableClient");
         });
-        services.AddHttpClient("WACS", config =>
-        {
-            config.DefaultRequestHeaders.Add("User-Agent", "ScriptureRenderingPipeline");
-        });
         services.AddHttpClient("WebhookDispatcher", config =>
         {
             config.DefaultRequestHeaders.Add("User-Agent", "ScriptureRenderingPipeline/WebhookDispatcher");
         });
         
         // Register webhook services
+        services.AddSingleton<GiteaClientFactory>();
         services.AddScoped<IWebhookService, AzureStorageWebhookStorage>();
         services.AddScoped<WebhookDispatcher>();
     })

--- a/ScriptureRenderingPipelineWorker/ProgressReporting.cs
+++ b/ScriptureRenderingPipelineWorker/ProgressReporting.cs
@@ -61,7 +61,7 @@ public class ProgressReporting
         }
         var repoUri = new Uri(message.RepoHtmlUrl);
         var giteaClient = _giteaClientFactory.CreateClient(repoUri.Host);
-        var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
+        using var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
         
         if (fileSystem == null)
         {

--- a/ScriptureRenderingPipelineWorker/ProgressReporting.cs
+++ b/ScriptureRenderingPipelineWorker/ProgressReporting.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Text.Json;
 using Azure.Messaging.ServiceBus;
 using BTTWriterLib;
@@ -17,15 +16,15 @@ public class ProgressReporting
 {
     private readonly ILogger<ProgressReporting> _log;
     private readonly ServiceBusClient _serviceBusClient;
-    private readonly HttpClient _wacsHttpClient;
     private readonly int _maxRepoSizeInMB;
+    private readonly GiteaClientFactory _giteaClientFactory;
     public ProgressReporting(ILogger<ProgressReporting> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory,
-    IHttpClientFactory httpClientFactory, IConfiguration configuration)
+        IConfiguration configuration, GiteaClientFactory giteaClientFactory)
     {
         _log = logger;
         _serviceBusClient = serviceBusClientFactory.CreateClient("ServiceBusClient");
-        _wacsHttpClient = httpClientFactory.CreateClient("WACS");
         _maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
+        _giteaClientFactory = giteaClientFactory;
     }
     [Function("ProgressReporting")]
     [ServiceBusOutput("VerseCountingResult", Connection = "ServiceBusConnectionString")]
@@ -60,12 +59,11 @@ public class ProgressReporting
                 Message = $"Repository size {message.RepoSizeInKB}KB exceeds the limit of {_maxRepoSizeInMB}MB, skipping"
             };
         }
-
-        var fileResult = await _wacsHttpClient.GetAsync(Utils.GenerateDownloadLink(message.RepoHtmlUrl, message.User, message.Repo, message.DefaultBranch));
+        var repoUri = new Uri(message.RepoHtmlUrl);
+        var giteaClient = _giteaClientFactory.CreateClient(repoUri.Host);
+        var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
         
-	    _log.LogDebug("Got status code: {StatusCode}", fileResult.StatusCode);
-        
-        if (fileResult.StatusCode == HttpStatusCode.NotFound)
+        if (fileSystem == null)
         {
 	        _log.LogWarning("Repo not found or is empty");
             return new VerseCountingResult(message)
@@ -74,17 +72,7 @@ public class ProgressReporting
                 Message = "Repo not found or is empty"
             };
         }
-        if (!fileResult.IsSuccessStatusCode)
-        {
-            _log.LogError("Failed to download repo: {StatusCode}", fileResult.StatusCode);
-		    throw new HttpRequestException("Got an unexpected response from Gitea expected 200 or 404 but got " + fileResult.StatusCode)
-		    {
-			    Data = { ["RepositoryUrl"] = message.RepoHtmlUrl, ["StatusCode"] = fileResult.StatusCode }
-		    };
-        }
         
-        var zipStream = await fileResult.Content.ReadAsStreamAsync();
-        var fileSystem = new ZipFileSystem(zipStream);
         var basePath = fileSystem.GetFolders().FirstOrDefault();
         RepoIdentificationResult details;
         try

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -111,7 +111,8 @@ public class RenderingTrigger
 	    var htmlUri = new Uri(message.RepoHtmlUrl);
 	    var giteaClient = _giteaClientFactory.CreateClient(htmlUri.Host);
 	    _log.LogInformation($"Downloading repo");
-	    rendererInput.FileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
+	    using var gitArchive = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
+	    rendererInput.FileSystem = gitArchive;
 	    
 	    if (rendererInput.FileSystem == null)
 	    {

--- a/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RenderingTrigger.cs
@@ -22,13 +22,13 @@ public class RenderingTrigger
 	private readonly BlobContainerClient _templateContainerClient;
 	private readonly string _pipelineBaseUrl;
 	private readonly string _resourcesUser;
-	private readonly HttpClient _wacsHttpClient;
 	private readonly int _maxRepoSizeInMB;
+	private readonly GiteaClientFactory _giteaClientFactory;
 
 	public RenderingTrigger(ILogger<RenderingTrigger> logger,
 		IAzureClientFactory<ServiceBusClient> serviceBusClientFactory,
 		IAzureClientFactory<BlobServiceClient> blobClientFactory,
-		IHttpClientFactory httpClientFactory, IConfiguration configuration)
+		IConfiguration configuration, GiteaClientFactory giteaClientFactory)
 	{
 		_log = logger;
 		_serviceBusClient = serviceBusClientFactory.CreateClient("ServiceBusClient");
@@ -37,8 +37,8 @@ public class RenderingTrigger
 		_templateContainerClient = blobServiceClient.GetBlobContainerClient(configuration.GetValue<string>("ScripturePipelineStorageTemplateContainer"));
 		_pipelineBaseUrl = configuration.GetValue<string>("ScriptureRenderingPipelineBaseUrl");
 		_resourcesUser = configuration.GetValue<string>("ScriptureRenderingPipelineResourcesUser");
-		_wacsHttpClient = httpClientFactory.CreateClient("WACS");
 		_maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
+		_giteaClientFactory = giteaClientFactory;
 	}
 	
     [Function("RenderingTrigger")]
@@ -58,26 +58,6 @@ public class RenderingTrigger
     }
 
 
-    private async Task<ZipFileSystem?> GetProjectAsync(WACSMessage message)
-    {
-	    var result = await _wacsHttpClient.GetAsync(Utils.GenerateDownloadLink(message.RepoHtmlUrl, message.User, message.Repo, message.DefaultBranch));
-	    if (result.StatusCode == HttpStatusCode.NotFound)
-	    {
-		    _log.LogWarning("Repository at {RepositoryUrl} is empty", message.RepoHtmlUrl);
-		    return null;
-	    }
-
-	    if (!result.IsSuccessStatusCode)
-	    {
-		    _log.LogError("Error downloading {RepositoryUrl} status code: {StatusCode}", message.RepoHtmlUrl, result.StatusCode);
-		    throw new HttpRequestException("Got an unexpected response from Gitea expected 200 or 404 but got " + result.StatusCode)
-		    {
-			    Data = { ["RepositoryUrl"] = message.RepoHtmlUrl, ["StatusCode"] = result.StatusCode }
-		    };
-	    }
-	    var zipStream = await result.Content.ReadAsStreamAsync();
-	    return new ZipFileSystem(zipStream);
-    }
 
     private static async Task<AppMeta?> GetAppMetaAsync(IZipFileSystem fileSystem, string basePath, ILogger log)
     {
@@ -128,8 +108,10 @@ public class RenderingTrigger
 
 	    var downloadPrintPageTemplateTask = GetTemplateAsync("print.html");
 
+	    var htmlUri = new Uri(message.RepoHtmlUrl);
+	    var giteaClient = _giteaClientFactory.CreateClient(htmlUri.Host);
 	    _log.LogInformation($"Downloading repo");
-	    rendererInput.FileSystem = await GetProjectAsync(message);
+	    rendererInput.FileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
 	    
 	    if (rendererInput.FileSystem == null)
 	    {

--- a/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
@@ -67,7 +67,7 @@ public class RepoAnalysisTrigger
 		{
 			var htmlUri = new Uri(message.RepoHtmlUrl);
 			var giteaClient = _giteaClientFactory.CreateClient(htmlUri.Host);
-			var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
+			using var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
 			if (fileSystem == null)
 			{
 				log.LogWarning("Repository {Username}/{Repo} not found on Gitea", message.User, message.Repo);

--- a/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
+++ b/ScriptureRenderingPipelineWorker/RepoAnalysisTrigger.cs
@@ -18,12 +18,14 @@ public class RepoAnalysisTrigger
 	private readonly ILogger<RepoAnalysisTrigger> log;
 	private readonly ServiceBusClient client;
 	private readonly int _maxRepoSizeInMB;
+	private readonly GiteaClientFactory _giteaClientFactory;
 
-	public RepoAnalysisTrigger(ILogger<RepoAnalysisTrigger> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory, IConfiguration configuration)
+	public RepoAnalysisTrigger(ILogger<RepoAnalysisTrigger> logger, IAzureClientFactory<ServiceBusClient> serviceBusClientFactory, IConfiguration configuration, GiteaClientFactory giteaClientFactory)
 	{
 		log = logger;
 		client = serviceBusClientFactory.CreateClient("ServiceBusClient");
 		_maxRepoSizeInMB = configuration.GetValue("MaxRepoSizeInMB", 0);
+		_giteaClientFactory = giteaClientFactory;
 	}
 
 	[Function("RepoAnalysisTrigger")]
@@ -45,7 +47,7 @@ public class RepoAnalysisTrigger
 		await sender.SendMessageAsync(output);
 	}
 
-	private static async Task<RepoAnalysisResult> AnalyzeRepoAsync(WACSMessage message, ILogger log, int maxRepoSizeInMB)
+	private async Task<RepoAnalysisResult> AnalyzeRepoAsync(WACSMessage message, ILogger log, int maxRepoSizeInMB)
 	{
 		log.LogInformation("Analyzing repository {Username}/{Repo}", message.User, message.Repo);
 
@@ -60,32 +62,19 @@ public class RepoAnalysisTrigger
 			return result;
 		}
 
-		// Download the repository
-		var fileResult = await Utils.httpClient.GetAsync(Utils.GenerateDownloadLink(message.RepoHtmlUrl, message.User, message.Repo, message.DefaultBranch));
-
-		log.LogDebug("Got status code: {StatusCode}", fileResult.StatusCode);
-
-		if (fileResult.StatusCode == HttpStatusCode.NotFound)
-		{
-			log.LogWarning("Repository not found or is empty");
-			result.Success = false;
-			result.Message = "Repository not found or is empty";
-			return result;
-		}
-
-		if (!fileResult.IsSuccessStatusCode)
-		{
-			log.LogError("Failed to download repository: {StatusCode}", fileResult.StatusCode);
-			result.Success = false;
-			result.Message = $"Failed to download repository: HTTP {fileResult.StatusCode}";
-			return result;
-		}
-
 		// Extract and analyze the repository
 		try
 		{
-			var zipStream = await fileResult.Content.ReadAsStreamAsync();
-			var fileSystem = new ZipFileSystem(zipStream);
+			var htmlUri = new Uri(message.RepoHtmlUrl);
+			var giteaClient = _giteaClientFactory.CreateClient(htmlUri.Host);
+			var fileSystem = await giteaClient.GetZipArchive(message.User, message.Repo, message.DefaultBranch);
+			if (fileSystem == null)
+			{
+				log.LogWarning("Repository {Username}/{Repo} not found on Gitea", message.User, message.Repo);
+				result.Success = false;
+				result.Message = "Repository not found on Gitea";
+				return result;
+			}
 			var basePath = fileSystem.GetFolders().FirstOrDefault();
 
 			if (basePath == null)


### PR DESCRIPTION
This adds several things
- A new gitea client factory that caches instances
- Updated actions

A thing to keep in mind is that .net allows you to have a configuration section map to a dictionary and that is how we handle multiple different hosts.

